### PR TITLE
PIL-1358 Validation Framework

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/validation/ValidationError.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/validation/ValidationError.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.validation
+trait ValidationError {
+  def errorCode:    String
+  def errorMessage: String
+  def field:        String
+}

--- a/app/uk/gov/hmrc/pillar2externalteststub/validation/ValidationResult.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/validation/ValidationResult.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.validation
+import cats.data.{NonEmptyChain, ValidatedNec}
+import cats.implicits._
+
+object ValidationResult {
+  type ValidationResult[A] = ValidatedNec[ValidationError, A]
+
+  def valid[A](a: A): ValidationResult[A] = a.validNec
+
+  def invalid[A](error: ValidationError): ValidationResult[A] = error.invalidNec
+
+  def invalidNec[A](errors: NonEmptyChain[ValidationError]): ValidationResult[A] = errors.invalid
+
+  def sequence[A](results: Seq[ValidationResult[A]]): ValidationResult[Seq[A]] =
+    results.sequence
+}

--- a/app/uk/gov/hmrc/pillar2externalteststub/validation/ValidationRule.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/validation/ValidationRule.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.validation
+
+import cats.implicits._
+import uk.gov.hmrc.pillar2externalteststub.validation.ValidationResult._
+import cats.data.Validated.Valid
+import cats.data.Validated.Invalid
+
+sealed trait ValidationStrategy
+case object AccumulateErrors extends ValidationStrategy
+case object FailFast extends ValidationStrategy
+
+trait ValidationRule[T] {
+  def validate(value: T): ValidationResult[T]
+}
+
+object ValidationRule {
+  def apply[T](f: T => ValidationResult[T]): ValidationRule[T] =
+    (value: T) => f(value)
+
+  def compose[T](rules: ValidationRule[T]*)(strategy: ValidationStrategy): ValidationRule[T] =
+    new ValidationRule[T] {
+      def validate(value: T): ValidationResult[T] =
+        strategy match {
+          case AccumulateErrors => validateAll(rules, value)
+          case FailFast         => validateFirstFailure(rules, value)
+        }
+    }
+
+  private def validateAll[T](rules: Seq[ValidationRule[T]], value: T): ValidationResult[T] =
+    rules.foldLeft(value.validNec[ValidationError]) { case (acc, rule) =>
+      (acc, rule.validate(value)).mapN((_, _) => value)
+    }
+
+  private def validateFirstFailure[T](rules: Seq[ValidationRule[T]], value: T): ValidationResult[T] =
+    rules.foldLeft[ValidationResult[T]](value.validNec[ValidationError]) {
+      case (Valid(_), rule)          => rule.validate(value)
+      case (invalid @ Invalid(_), _) => invalid
+    }
+}

--- a/app/uk/gov/hmrc/pillar2externalteststub/validation/ValidationRule.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/validation/ValidationRule.scala
@@ -16,10 +16,10 @@
 
 package uk.gov.hmrc.pillar2externalteststub.validation
 
+import cats.data.Validated.Invalid
+import cats.data.Validated.Valid
 import cats.implicits._
 import uk.gov.hmrc.pillar2externalteststub.validation.ValidationResult._
-import cats.data.Validated.Valid
-import cats.data.Validated.Invalid
 
 sealed trait ValidationStrategy
 case object AccumulateErrors extends ValidationStrategy

--- a/app/uk/gov/hmrc/pillar2externalteststub/validation/ValidationSyntax.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/validation/ValidationSyntax.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.validation
+
+import ValidationResult._
+trait ValidationSyntax {
+  implicit class ValidateOps[A](value: A) {
+    def validate(implicit rule: ValidationRule[A]): ValidationResult[A] =
+      rule.validate(value)
+  }
+}
+
+object syntax extends ValidationSyntax

--- a/test/uk/gov/hmrc/pillar2externalteststub/validation/ValidationResultSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/validation/ValidationResultSpec.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.validation
+
+import cats.implicits._
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.pillar2externalteststub.validation.ValidationResult._
+import uk.gov.hmrc.pillar2externalteststub.validation.models.TestValidationError._
+
+class ValidationResultSpec extends AnyWordSpec with Matchers {
+  "ValidationResult" should {
+    "create valid results" in {
+      val result = valid("test")
+      result.isValid mustBe true
+    }
+
+    "create invalid results" in {
+      val error  = MandatoryFieldMissing("testField")
+      val result = invalid[String](error)
+      result.isInvalid mustBe true
+    }
+
+    "sequence multiple results" in {
+      val results = Seq(
+        valid("test1"),
+        valid("test2")
+      )
+
+      val sequenced = sequence(results)
+      sequenced.isValid mustBe true
+      sequenced.toOption.get must contain theSameElementsAs Seq("test1", "test2")
+    }
+
+    "sequence multiple results with some errors" in {
+      val results = Seq(
+        valid("test1"),
+        invalid(MandatoryFieldMissing("test2"))
+      )
+
+      val sequenced = sequence(results)
+      sequenced.isInvalid mustBe true
+      sequenced.toEither match {
+        case Left(errors) =>
+          errors.length mustBe 1
+          errors.head mustBe MandatoryFieldMissing("test2")
+        case Right(_) => fail("Expected invalid result")
+      }
+    }
+
+    "accumulate multiple errors when sequencing" in {
+      val results = Seq(
+        invalid[String](MandatoryFieldMissing("field1")),
+        invalid[String](MandatoryFieldMissing("field2"))
+      )
+
+      val sequenced = sequence(results)
+      sequenced.isInvalid mustBe true
+      sequenced.toEither match {
+        case Left(errors) =>
+          errors.length mustBe 2
+          errors.toList must contain(MandatoryFieldMissing("field1"))
+          errors.toList must contain(MandatoryFieldMissing("field2"))
+        case Right(_) => fail("Expected invalid result")
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/pillar2externalteststub/validation/ValidationRuleSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/validation/ValidationRuleSpec.scala
@@ -51,7 +51,7 @@ class ValidationRuleSpec extends AnyWordSpec with Matchers {
       val rule2 = ValidationRule[String](_ => invalid(MandatoryFieldMissing("field2")))
 
       val validator = ValidationRule.compose(rule1, rule2)(AccumulateErrors)
-      val result = validator.validate("test")
+      val result    = validator.validate("test")
 
       result.isInvalid mustBe true
       result.toEither match {
@@ -68,7 +68,7 @@ class ValidationRuleSpec extends AnyWordSpec with Matchers {
       val rule2 = ValidationRule[String](_ => invalid(MandatoryFieldMissing("field2")))
 
       val validator = ValidationRule.compose(rule1, rule2)(FailFast)
-      val result = validator.validate("test")
+      val result    = validator.validate("test")
 
       result.isInvalid mustBe true
       result.toEither match {
@@ -96,7 +96,7 @@ class ValidationRuleSpec extends AnyWordSpec with Matchers {
       val emptyResult = validator.validate("")
       emptyResult.isInvalid mustBe true
       emptyResult.toEither match {
-        case Left(errors) => 
+        case Left(errors) =>
           errors.length mustBe 1
           errors.head mustBe MandatoryFieldMissing("test")
         case Right(_) => fail("Expected validation to fail")
@@ -106,7 +106,7 @@ class ValidationRuleSpec extends AnyWordSpec with Matchers {
       val tooLongResult = validator.validate("toolong")
       tooLongResult.isInvalid mustBe true
       tooLongResult.toEither match {
-        case Left(errors) => 
+        case Left(errors) =>
           errors.length mustBe 1
           errors.head mustBe MaxLengthExceeded("test", 5)
         case Right(_) => fail("Expected validation to fail")

--- a/test/uk/gov/hmrc/pillar2externalteststub/validation/ValidationRuleSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/validation/ValidationRuleSpec.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.validation
+
+import cats.implicits._
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.pillar2externalteststub.validation.ValidationResult._
+import uk.gov.hmrc.pillar2externalteststub.validation.models.TestValidationError._
+class ValidationRuleSpec extends AnyWordSpec with Matchers {
+  "ValidationRule" should {
+    "create simple validation rules" in {
+      val rule = ValidationRule[String] { str =>
+        if (str.nonEmpty) valid(str)
+        else invalid(MandatoryFieldMissing("test"))
+      }
+
+      // Test valid case
+      val validResult = rule.validate("test")
+      validResult.isValid mustBe true
+      validResult.toEither match {
+        case Right(value) => value mustBe "test"
+        case Left(_)      => fail("Expected validation to succeed")
+      }
+
+      // Test invalid case
+      val invalidResult = rule.validate("")
+      invalidResult.isInvalid mustBe true
+      invalidResult.toEither match {
+        case Left(errors) => errors.head mustBe MandatoryFieldMissing("test")
+        case Right(_)     => fail("Expected validation to fail")
+      }
+    }
+
+    "compose rules with accumulating errors" in {
+      val rule1 = ValidationRule[String](_ => invalid(MandatoryFieldMissing("field1")))
+      val rule2 = ValidationRule[String](_ => invalid(MandatoryFieldMissing("field2")))
+
+      val validator = ValidationRule.compose(rule1, rule2)(AccumulateErrors)
+      val result = validator.validate("test")
+
+      result.isInvalid mustBe true
+      result.toEither match {
+        case Left(errors) =>
+          errors.length mustBe 2
+          errors.toList must contain(MandatoryFieldMissing("field1"))
+          errors.toList must contain(MandatoryFieldMissing("field2"))
+        case Right(_) => fail("Expected validation to fail")
+      }
+    }
+
+    "compose rules with fail-fast strategy" in {
+      val rule1 = ValidationRule[String](_ => invalid(MandatoryFieldMissing("field1")))
+      val rule2 = ValidationRule[String](_ => invalid(MandatoryFieldMissing("field2")))
+
+      val validator = ValidationRule.compose(rule1, rule2)(FailFast)
+      val result = validator.validate("test")
+
+      result.isInvalid mustBe true
+      result.toEither match {
+        case Left(errors) =>
+          errors.length mustBe 1
+          errors.head mustBe MandatoryFieldMissing("field1")
+        case Right(_) => fail("Expected validation to fail")
+      }
+    }
+
+    "compose complex validation rules with fail-fast" in {
+      val nonEmptyRule = ValidationRule[String] { str =>
+        if (str.nonEmpty) valid(str)
+        else invalid(MandatoryFieldMissing("test"))
+      }
+
+      val maxLengthRule = ValidationRule[String] { str =>
+        if (str.length <= 5) valid(str)
+        else invalid(MaxLengthExceeded("test", 5))
+      }
+
+      val validator = ValidationRule.compose(nonEmptyRule, maxLengthRule)(FailFast)
+
+      // Test empty string - should only get the first error
+      val emptyResult = validator.validate("")
+      emptyResult.isInvalid mustBe true
+      emptyResult.toEither match {
+        case Left(errors) => 
+          errors.length mustBe 1
+          errors.head mustBe MandatoryFieldMissing("test")
+        case Right(_) => fail("Expected validation to fail")
+      }
+
+      // Test too long string - should only get the max length error
+      val tooLongResult = validator.validate("toolong")
+      tooLongResult.isInvalid mustBe true
+      tooLongResult.toEither match {
+        case Left(errors) => 
+          errors.length mustBe 1
+          errors.head mustBe MaxLengthExceeded("test", 5)
+        case Right(_) => fail("Expected validation to fail")
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/pillar2externalteststub/validation/ValidationSyntaxSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/validation/ValidationSyntaxSpec.scala
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.validation
+
+import cats.data.NonEmptyChain
+import cats.implicits._
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.pillar2externalteststub.validation.models.TestValidationError._
+
+import java.time.LocalDate
+
+import ValidationResult._
+
+case class TestLiability(
+  entityName: String,
+  amount:     BigDecimal
+)
+
+case class TestSubmission(
+  periodStart: LocalDate,
+  periodEnd:   LocalDate,
+  liabilities: List[TestLiability]
+)
+
+object TestSubmission {
+  val dateValidation: ValidationRule[TestSubmission] = ValidationRule[TestSubmission] { submission =>
+    if (submission.periodEnd.isAfter(submission.periodStart)) valid(submission)
+    else invalid(InvalidDateRange("/periodDates", "End date must be after start date"))
+  }
+
+  val liabilityValidation: ValidationRule[TestSubmission] = ValidationRule[TestSubmission] { submission =>
+    if (submission.liabilities.nonEmpty) valid(submission)
+    else invalid(MandatoryFieldMissing("/liabilities"))
+  }
+
+  val amountValidation: ValidationRule[TestSubmission] = ValidationRule[TestSubmission] { submission =>
+    val invalidAmounts = submission.liabilities.zipWithIndex.collect {
+      case (liability, index) if liability.amount < 0 =>
+        InvalidAmount(s"/liabilities/$index/amount", liability.amount)
+    }
+    if (invalidAmounts.isEmpty) valid(submission)
+    else invalidNec(NonEmptyChain.fromSeq(invalidAmounts).get)
+  }
+
+  implicit val validator: ValidationRule[TestSubmission] = 
+    ValidationRule.compose(dateValidation, liabilityValidation, amountValidation)(AccumulateErrors)
+}
+
+class ValidationSyntaxSpec extends AnyWordSpec with Matchers {
+  import syntax._
+
+  "ValidationSyntax" should {
+    "validate a correct submission" in {
+      val submission = TestSubmission(
+        periodStart = LocalDate.of(2024, 1, 1),
+        periodEnd = LocalDate.of(2024, 12, 31),
+        liabilities = List(
+          TestLiability("Entity 1", 1000),
+          TestLiability("Entity 2", 2000)
+        )
+      )
+
+      val result = submission.validate
+      result.isValid mustBe true
+    }
+
+    "fail validation for invalid dates" in {
+      val submission = TestSubmission(
+        periodStart = LocalDate.of(2024, 12, 31),
+        periodEnd = LocalDate.of(2024, 1, 1),
+        liabilities = List(TestLiability("Entity 1", 1000))
+      )
+
+      val result = submission.validate
+      result.isInvalid mustBe true
+      result.toEither match {
+        case Left(errors) => errors.head mustBe a[InvalidDateRange]
+        case Right(_)     => fail("Expected validation to fail")
+      }
+    }
+
+    "accumulate multiple validation errors by default" in {
+      val submission = TestSubmission(
+        periodStart = LocalDate.of(2024, 12, 31),
+        periodEnd = LocalDate.of(2024, 1, 1),
+        liabilities = List(
+          TestLiability("Entity 1", -1000),
+          TestLiability("Entity 2", -2000)
+        )
+      )
+
+      val result = submission.validate
+      result.isInvalid mustBe true
+      result.toEither match {
+        case Left(errors) =>
+          errors.length mustBe 3
+          errors.collect { case e: InvalidDateRange => e }.length mustBe 1
+          errors.collect { case e: InvalidAmount => e }.length mustBe 2
+        case Right(_) => fail("Expected validation to fail")
+      }
+    }
+
+    "use fail-fast validation when configured" in {
+      val failFastValidator = ValidationRule.compose(
+        TestSubmission.dateValidation,
+        TestSubmission.liabilityValidation,
+        TestSubmission.amountValidation
+      )(FailFast)
+
+      val submission = TestSubmission(
+        periodStart = LocalDate.of(2024, 12, 31),
+        periodEnd = LocalDate.of(2024, 1, 1),
+        liabilities = List(
+          TestLiability("Entity 1", -1000),
+          TestLiability("Entity 2", -2000)
+        )
+      )
+
+      val result = submission.validate(failFastValidator)
+      result.isInvalid mustBe true
+      result.toEither match {
+        case Left(errors) =>
+          errors.length mustBe 1
+          errors.head mustBe a[InvalidDateRange]
+        case Right(_) => fail("Expected validation to fail")
+      }
+    }
+  }
+}
+

--- a/test/uk/gov/hmrc/pillar2externalteststub/validation/ValidationSyntaxSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/validation/ValidationSyntaxSpec.scala
@@ -57,7 +57,7 @@ object TestSubmission {
     else invalidNec(NonEmptyChain.fromSeq(invalidAmounts).get)
   }
 
-  implicit val validator: ValidationRule[TestSubmission] = 
+  implicit val validator: ValidationRule[TestSubmission] =
     ValidationRule.compose(dateValidation, liabilityValidation, amountValidation)(AccumulateErrors)
 }
 
@@ -142,4 +142,3 @@ class ValidationSyntaxSpec extends AnyWordSpec with Matchers {
     }
   }
 }
-

--- a/test/uk/gov/hmrc/pillar2externalteststub/validation/models/TestValidationError.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/validation/models/TestValidationError.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.validation.models
+
+import uk.gov.hmrc.pillar2externalteststub.validation.ValidationError
+
+sealed trait TestValidationError extends ValidationError {
+  def field: String
+}
+
+object TestValidationError {
+  case class MandatoryFieldMissing(field: String) extends TestValidationError {
+    override def errorCode:    String = "MANDATORY_FIELD_MISSING"
+    override def errorMessage: String = s"Mandatory field is missing"
+  }
+
+  case class MaxLengthExceeded(field: String, maxLength: Int) extends TestValidationError {
+    override def errorCode:    String = "MAX_LENGTH_EXCEEDED"
+    override def errorMessage: String = s"Field exceeds maximum length of $maxLength"
+  }
+
+  case class InvalidDateRange(field: String, details: String) extends TestValidationError {
+    override def errorCode:    String = "INVALID_DATE_RANGE"
+    override def errorMessage: String = details
+  }
+
+  case class InvalidAmount(field: String, amount: BigDecimal) extends TestValidationError {
+    override def errorCode:    String = "INVALID_AMOUNT"
+    override def errorMessage: String = s"Amount must be non-negative"
+  }
+}


### PR DESCRIPTION
This PR introduces a validation framework using cats' `ValidatedNec` that supports both accumulative and fail-fast validation strategies. The framework is designed to be generic, type-safe, and reusable across different validation needs.

## Key Features
- Type-safe validation using cats' `Validated` and `NonEmptyChain`
- Flexible validation strategies (accumulate errors or fail-fast)
- Composable validation rules
- Clean syntax for validation through implicits
- validation strategy defined at rule composition time

## Usage Examples

### 1. Simple Validation Rule
```scala
// Define a validation error
case class MinLengthError(field: String, minLength: Int) extends ValidationError {
  override def errorCode: String = "MIN_LENGTH"
  override def errorMessage: String = s"Must be at least $minLength characters"
}

// Create a simple validation rule
val nameRule = ValidationRule[String] { name =>
  if (name.length >= 2) valid(name)
  else invalid(MinLengthError("name", 2))
}

// Use the rule directly
nameRule.validate("A")     // Invalid: MinLengthError
nameRule.validate("Alex")  // Valid: "Alex"
```

### 2. Composing Multiple Rules
```scala
// Define validation rules for an email address
val nonEmptyRule = ValidationRule[String] { email =>
  if (email.nonEmpty) valid(email)
  else invalid(MandatoryFieldMissing("email"))
}

val formatRule = ValidationRule[String] { email =>
  if (email.contains("@")) valid(email)
  else invalid(InvalidFormat("email", "Must contain @ symbol"))
}

// Compose rules with accumulating strategy
val emailValidator = ValidationRule.compose(
  nonEmptyRule,
  formatRule
)(AccumulateErrors)

// Test cases with accumulating validator
emailValidator.validate("")      
// Invalid: MandatoryFieldMissing("email"), InvalidFormat("email")

emailValidator.validate("test@example.com")  
// Valid: "test@example.com"

// Same rules with fail-fast strategy
val failFastEmailValidator = ValidationRule.compose(
  nonEmptyRule,
  formatRule
)(FailFast)

failFastEmailValidator.validate("")
// Invalid: MandatoryFieldMissing("email") - stops here, doesn't check format
```

### 3. Domain Object Validation
```scala
case class User(name: String, email: String, age: Int)

object User {
  // Individual validation rules
  val nameValidation = ValidationRule[User] { user =>
    if (user.name.nonEmpty) valid(user)
    else invalid(MandatoryFieldMissing("name"))
  }

  val emailValidation = ValidationRule[User] { user =>
    if (user.email.contains("@")) valid(user)
    else invalid(InvalidFormat("email"))
  }

  val ageValidation = ValidationRule[User] { user =>
    if (user.age >= 18) valid(user)
    else invalid(InvalidValue("age", "Must be 18 or older"))
  }

  // Compose rules into a single validator
  implicit val validator: ValidationRule[User] = 
    ValidationRule.compose(
      nameValidation,
      emailValidation,
      ageValidation
    )(AccumulateErrors)
}
```

### 4. Using the Validation Syntax
```scala
import validation.syntax._

// Using implicit validator
val user = User("", "invalid", 16)
val result = user.validate
// Invalid: MandatoryFieldMissing("name"), 
//          InvalidFormat("email"), 
//          InvalidValue("age")

// Using explicit validator with different strategy
val failFastValidator = ValidationRule.compose(
  User.nameValidation,
  User.emailValidation,
  User.ageValidation
)(FailFast)

val fastResult = user.validate(failFastValidator)
// Invalid: MandatoryFieldMissing("name")

// Pattern matching results
result.toEither match {
  case Right(validUser) => // Handle valid user
  case Left(errors)     => // Handle validation errors
}
```

## Next Steps
- Add specific validation rules for UKTR submissions stub

## Related Links
- [Cats Validated Documentation](https://typelevel.org/cats/datatypes/validated.html)