### PR TITLE
PIL-1639: Add UKTR mongodb persistence

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/SubmitUKTRController.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/SubmitUKTRController.scala
@@ -25,9 +25,10 @@ import uk.gov.hmrc.pillar2externalteststub.helpers.UKTRHelper._
 import uk.gov.hmrc.pillar2externalteststub.models.subscription.SubscriptionSuccessResponse
 import uk.gov.hmrc.pillar2externalteststub.models.uktr.LiabilityReturnSuccess.successfulUKTRResponse
 import uk.gov.hmrc.pillar2externalteststub.models.uktr.NilReturnSuccess.successfulNilReturnResponse
-import uk.gov.hmrc.pillar2externalteststub.models.uktr.UKTRDetailedError.{MissingPLRReference, SubscriptionNotFound, TaxObligationFulfilled}
+import uk.gov.hmrc.pillar2externalteststub.models.uktr.UKTRDetailedError.{MissingPLRReference, SubscriptionNotFound}
 import uk.gov.hmrc.pillar2externalteststub.models.uktr.UKTRSimpleError.{InvalidJsonError, SAPError}
 import uk.gov.hmrc.pillar2externalteststub.models.uktr._
+import uk.gov.hmrc.pillar2externalteststub.repositories.UKTRSubmissionRepository
 import uk.gov.hmrc.pillar2externalteststub.validation.syntax.ValidateOps
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
@@ -37,7 +38,8 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class SubmitUKTRController @Inject() (
   cc:          ControllerComponents,
-  authFilter:  AuthActionFilter
+  authFilter:  AuthActionFilter,
+  repository:  UKTRSubmissionRepository
 )(implicit ec: ExecutionContext)
     extends BackendController(cc)
     with Logging {
@@ -49,9 +51,7 @@ class SubmitUKTRController @Inject() (
         Future.successful(UnprocessableEntity(Json.toJson(MissingPLRReference)))
       case Some(plrReference) =>
         plrReference match {
-          case UnprocessableEntityPlrId => Future.successful(UnprocessableEntity(Json.toJson(TaxObligationFulfilled)))
-          case ServerErrorPlrId         => Future.successful(InternalServerError(Json.toJson(SAPError)))
-          case BadRequestPlrId          => Future.successful(BadRequest(Json.toJson(InvalidJsonError())))
+          case ServerErrorPlrId => Future.successful(InternalServerError(Json.toJson(SAPError)))
           case _ =>
             retrieveSubscription(plrReference)._2 match {
               case _: SubscriptionSuccessResponse => validateRequest(plrReference, request)
@@ -66,12 +66,12 @@ class SubmitUKTRController @Inject() (
       case JsSuccess(uktrRequest: UKTRLiabilityReturn, _) =>
         Future.successful(uktrRequest.validate(plrReference).toEither).flatMap {
           case Left(errors) => UKTRErrorTransformer.from422ToJson(errors)
-          case Right(_)     => Future.successful(Created(Json.toJson(successfulUKTRResponse)))
+          case Right(_)     => repository.insert(uktrRequest, plrReference).map(_ => Created(Json.toJson(successfulUKTRResponse)))
         }
       case JsSuccess(nilReturnRequest: UKTRNilReturn, _) =>
         Future.successful(nilReturnRequest.validate(plrReference).toEither).flatMap {
           case Left(errors) => UKTRErrorTransformer.from422ToJson(errors)
-          case Right(_)     => Future.successful(Created(Json.toJson(successfulNilReturnResponse)))
+          case Right(_)     => repository.insert(nilReturnRequest, plrReference).map(_ => Created(Json.toJson(successfulNilReturnResponse)))
         }
       case JsError(errors) =>
         val errorMessage = errors

--- a/app/uk/gov/hmrc/pillar2externalteststub/helpers/SubscriptionHelper.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/helpers/SubscriptionHelper.scala
@@ -31,8 +31,8 @@ object SubscriptionHelper {
     plrReference match {
       case "XEPLR0123456500" => (InternalServerError, ServerError500.response)
       case "XEPLR0123456503" => (ServiceUnavailable, ServiceUnavailable503.response)
-      case "XEPLR5555555555" => (Ok, successfulDomesticOnlyResponse)
+      case "XEPLR5555555554" => (NotFound, NotFoundSubscription.response)
       case "XEPLR1234567890" => (Ok, successfulNonDomesticResponse)
-      case _                 => (NotFound, NotFoundSubscription.response)
+      case _                 => (Ok, successfulDomesticOnlyResponse)
     }
 }

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/error/StubError.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/error/StubError.scala
@@ -44,5 +44,5 @@ case class OrganisationNotFound(pillar2Id: String) extends StubError {
 
 case class DatabaseError(error: String) extends StubError {
   override val code:    String = "DATABASE_ERROR"
-  override val message: String = s"Database operation failed: $error"
+  override val message: String = error
 }

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRError.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRError.scala
@@ -74,6 +74,15 @@ object UKTRDetailedError {
         text = "Pillar 2 ID missing or invalid"
       )
     )
+
+  def RequestCouldNotBeProcessed: DetailedErrorResponse =
+    DetailedErrorResponse(
+      UKTRDetailedError(
+        processingDate = nowZonedDateTime,
+        code = REQUEST_COULD_NOT_BE_PROCESSED_003,
+        text = "Request could not be processed"
+      )
+    )
 }
 
 object UKTRErrorCodes {

--- a/app/uk/gov/hmrc/pillar2externalteststub/repositories/OrganisationRepository.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/repositories/OrganisationRepository.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.pillar2externalteststub.repositories
 
 import org.bson.conversions.Bson
-import org.mongodb.scala.model.IndexModel
 import org.mongodb.scala.model._
 import play.api.libs.json._
 import uk.gov.hmrc.mongo.MongoComponent

--- a/app/uk/gov/hmrc/pillar2externalteststub/repositories/UKTRSubmissionRepository.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/repositories/UKTRSubmissionRepository.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.repositories
+
+import cats.implicits.toTraverseOps
+import org.mongodb.scala.bson.ObjectId
+import org.mongodb.scala.model.Filters._
+import org.mongodb.scala.model.Indexes.descending
+import org.mongodb.scala.model.{IndexModel, IndexOptions, Indexes}
+import play.api.libs.json._
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+import uk.gov.hmrc.pillar2externalteststub.config.AppConfig
+import uk.gov.hmrc.pillar2externalteststub.models.error.DatabaseError
+import uk.gov.hmrc.pillar2externalteststub.models.uktr.UKTRDetailedError.RequestCouldNotBeProcessed
+import uk.gov.hmrc.pillar2externalteststub.models.uktr.{DetailedErrorResponse, UKTRSubmission}
+
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class UKTRSubmissionRepository @Inject() (config: AppConfig, mongoComponent: MongoComponent)(implicit ec: ExecutionContext)
+    extends PlayMongoRepository[JsObject](
+      collectionName = "uktr-submissions",
+      mongoComponent = mongoComponent,
+      domainFormat = implicitly[Format[JsObject]],
+      indexes = Seq(
+        IndexModel(
+          Indexes.ascending("createdAt"),
+          IndexOptions()
+            .name("createdAtTTL")
+            .expireAfter(config.defaultDataExpireInDays, TimeUnit.DAYS)
+        )
+      )
+    ) {
+
+  def insert(submission: UKTRSubmission, pillar2Id: String, isAmendment: Boolean = false): Future[Boolean] = {
+    val document = Json.obj(
+      "_id"         -> new ObjectId().toString,
+      "pillar2Id"   -> pillar2Id,
+      "isAmendment" -> isAmendment,
+      "data"        -> Json.toJson(submission).as[JsObject],
+      "createdAt"   -> Json.obj("$date" -> Instant.now.toEpochMilli)
+    )
+
+    collection
+      .insertOne(document)
+      .toFuture()
+      .map(_ => true)
+      .recoverWith { case e: Exception =>
+        Future.failed(DatabaseError(s"Failed to ${if (isAmendment) "amend" else "create"} UKTR - ${e.getMessage}"))
+      }
+  }
+
+  def update(submission: UKTRSubmission, pillar2Id: String): Future[Either[DetailedErrorResponse, Boolean]] =
+    findByPillar2Id(pillar2Id).flatMap(
+      _.toRight(RequestCouldNotBeProcessed)
+        .traverse(_ => insert(submission, pillar2Id, isAmendment = true))
+    )
+
+  def findByPillar2Id(pillar2Id: String): Future[Option[JsObject]] =
+    collection
+      .find(equal("pillar2Id", pillar2Id))
+      .sort(descending("createdAt"))
+      .headOption()
+}

--- a/build.sbt
+++ b/build.sbt
@@ -10,11 +10,10 @@ ThisBuild / majorVersion := 0
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin) // Required to prevent https://github.com/scalatest/scalatest/issues/1427
+  .settings(CodeCoverageSettings.settings *)
   .settings(
-    ScoverageKeys.coverageExcludedFiles :=
-      "<empty>;com.kenshoo.play.metrics.*;.*definition.*;prod.*;testOnlyDoNotUseInAppConf.*;.*stubs.*;.*models.*;" +
-        "app.*;.*BuildInfo.*;.*Routes.*;.*repositories.*;.*package.*;.*controllers.test.*;.*services.test.*;.*metrics.*",
-    ScoverageKeys.coverageMinimumStmtTotal := 80,
+    ScoverageKeys.coverageExcludedFiles := ".*models.*;.*package.*;.*config.*;.*helpers.*",
+    ScoverageKeys.coverageMinimumStmtTotal := 90,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true,
     PlayKeys.playDefaultPort := 10055,
@@ -37,7 +36,6 @@ lazy val microservice = Project(appName, file("."))
     )
   )
   .settings(resolvers += Resolver.jcenterRepo)
-  .settings(CodeCoverageSettings.settings *)
 
 addCommandAlias("prePrChecks", ";scalafmtCheckAll;scalafmtSbtCheck;scalafixAll --check")
 addCommandAlias("lint", ";scalafmtAll;scalafmtSbt;scalafixAll")

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/UKTRSubmissionISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/UKTRSubmissionISpec.scala
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub
+
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.{JsObject, Json}
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.SessionKeys.authToken
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+import uk.gov.hmrc.pillar2externalteststub.helpers.UKTRDataFixture
+import uk.gov.hmrc.pillar2externalteststub.helpers.UKTRHelper._
+import uk.gov.hmrc.pillar2externalteststub.models.uktr._
+import uk.gov.hmrc.pillar2externalteststub.repositories.UKTRSubmissionRepository
+
+import scala.concurrent.ExecutionContext
+
+class UKTRSubmissionISpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaFutures
+    with IntegrationPatience
+    with GuiceOneServerPerSuite
+    with DefaultPlayMongoRepositorySupport[JsObject]
+    with UKTRDataFixture {
+
+  override protected val databaseName: String = "test-uktr-submission-integration"
+  private val httpClient = app.injector.instanceOf[HttpClientV2]
+  private val baseUrl    = s"http://localhost:$port"
+  override protected val repository: UKTRSubmissionRepository = app.injector.instanceOf[UKTRSubmissionRepository]
+  implicit val ec:                   ExecutionContext         = app.injector.instanceOf[ExecutionContext]
+  implicit val hc:                   HeaderCarrier            = HeaderCarrier()
+
+  override def fakeApplication(): Application =
+    GuiceApplicationBuilder()
+      .configure(
+        "mongodb.uri"     -> s"mongodb://localhost:27017/$databaseName",
+        "metrics.enabled" -> false
+      )
+      .build()
+
+  private def submitUKTR(submission: UKTRSubmission, pillar2Id: String): HttpResponse =
+    httpClient
+      .post(url"$baseUrl/RESTAdapter/PLR/UKTaxReturn")
+      .withBody(Json.toJson(submission))
+      .setHeader("Authorization" -> authToken, "X-Pillar2-Id" -> pillar2Id)
+      .execute[HttpResponse]
+      .futureValue
+
+  private def amendUKTR(submission: UKTRSubmission, pillar2Id: String): HttpResponse =
+    httpClient
+      .put(url"$baseUrl/RESTAdapter/PLR/UKTaxReturn")
+      .withBody(Json.toJson(submission))
+      .setHeader("Authorization" -> authToken, "X-Pillar2-Id" -> pillar2Id)
+      .execute[HttpResponse]
+      .futureValue
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    repository.collection.drop()
+    ()
+  }
+
+  "UKTR endpoints" should {
+    "handle liability returns" should {
+      "successfully submit a new liability return" in {
+        val response = submitUKTR(liabilitySubmission, pillar2Id)
+        response.status shouldBe 201
+
+        val submission = repository.findByPillar2Id(pillar2Id).futureValue
+        submission shouldBe defined
+      }
+
+      "successfully amend an existing liability return" in {
+        submitUKTR(liabilitySubmission, pillar2Id).status
+        val updatedBody      = Json.fromJson[UKTRSubmission](validRequestBody.as[JsObject] ++ Json.obj("accountingPeriodFrom" -> "2024-01-01")).get
+        val response         = amendUKTR(updatedBody, pillar2Id)
+        val latestSubmission = repository.findByPillar2Id(pillar2Id).futureValue
+
+        response.status             shouldBe 200
+        latestSubmission.get.toString should include(""""accountingPeriodFrom":"2024-01-01"""")
+      }
+
+      "return 422 when trying to amend non-existent liability return" in {
+        val response = amendUKTR(liabilitySubmission, "invalidPlr2Id")
+
+        response.status                                shouldBe 422
+        (response.json \ "errors" \ "code").as[String] shouldBe "003"
+        (response.json \ "errors" \ "text").as[String] shouldBe "Request could not be processed"
+      }
+
+      "return 422 when trying to amend non-existent nil return" in {
+        val response = amendUKTR(nilSubmission, "invalidPlr2Id")
+
+        response.status                                shouldBe 422
+        (response.json \ "errors" \ "code").as[String] shouldBe "003"
+        (response.json \ "errors" \ "text").as[String] shouldBe "Request could not be processed"
+      }
+    }
+
+    "handle nil returns" should {
+      "successfully submit a new nil return" in {
+        val response = submitUKTR(nilSubmission, pillar2Id)
+        response.status shouldBe 201
+
+        val submission = repository.findByPillar2Id(pillar2Id).futureValue
+        submission shouldBe defined
+      }
+
+      "successfully amend an existing nil return" in {
+        submitUKTR(nilSubmission, pillar2Id).status shouldBe 201
+
+        val response = amendUKTR(nilSubmission, pillar2Id)
+        response.status shouldBe 200
+      }
+    }
+
+    "handle error cases" should {
+      "return 400 for invalid JSON" in {
+        val response = httpClient
+          .post(url"$baseUrl/RESTAdapter/PLR/UKTaxReturn")
+          .withBody(Json.obj("invalid" -> "data"))
+          .setHeader("Authorization" -> authToken, "X-Pillar2-Id" -> pillar2Id)
+          .execute[HttpResponse]
+          .futureValue
+
+        response.status shouldBe 400
+      }
+
+      "return 422 when Pillar2 ID header is missing" in {
+        val response = httpClient
+          .post(url"$baseUrl/RESTAdapter/PLR/UKTaxReturn")
+          .withBody(Json.toJson(liabilitySubmission))
+          .setHeader("Authorization" -> authToken)
+          .execute[HttpResponse]
+          .futureValue
+
+        response.status shouldBe 422
+      }
+
+      "return appropriate error for test PLR IDs" in {
+        val serverErrorResponse = submitUKTR(liabilitySubmission, ServerErrorPlrId)
+        serverErrorResponse.status shouldBe 500
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/AmendUKTRControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/AmendUKTRControllerSpec.scala
@@ -16,23 +16,55 @@
 
 package uk.gov.hmrc.pillar2externalteststub.controllers
 
+import org.mockito.ArgumentMatchers.{any, argThat}
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterEach, OptionValues}
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsValue, Json}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import play.api.{Application, inject}
 import uk.gov.hmrc.pillar2externalteststub.helpers.UKTRDataFixture
 import uk.gov.hmrc.pillar2externalteststub.helpers.UKTRHelper._
+import uk.gov.hmrc.pillar2externalteststub.models.uktr.UKTRDetailedError.RequestCouldNotBeProcessed
+import uk.gov.hmrc.pillar2externalteststub.models.uktr.{UKTRLiabilityReturn, UKTRNilReturn, UKTRSubmission}
+import uk.gov.hmrc.pillar2externalteststub.repositories.UKTRSubmissionRepository
 
 import java.time._
+import scala.concurrent.Future
 
-class AmendUKTRControllerSpec extends UKTRDataFixture {
+class AmendUKTRControllerSpec
+    extends AnyFreeSpec
+    with Matchers
+    with GuiceOneAppPerSuite
+    with OptionValues
+    with UKTRDataFixture
+    with MockitoSugar
+    with BeforeAndAfterEach {
+
+  private val mockRepository = mock[UKTRSubmissionRepository]
 
   private def createRequest(plrId: String, body: JsValue): FakeRequest[JsValue] =
     FakeRequest(PUT, routes.AmendUKTRController.amendUKTR.url)
       .withHeaders("Content-Type" -> "application/json", authHeader, "X-Pillar2-Id" -> plrId)
       .withBody(body)
 
+  override def fakeApplication(): Application =
+    GuiceApplicationBuilder()
+      .overrides(inject.bind[UKTRSubmissionRepository].toInstance(mockRepository))
+      .build()
+
+  override def beforeEach(): Unit = reset(mockRepository)
+
   "return OK with success response for a valid uktr amendment" in {
+    when(mockRepository.update(argThat((submission: UKTRSubmission) => submission.isInstanceOf[UKTRLiabilityReturn]), any[String]))
+      .thenReturn(Future.successful(Right(true)))
+
     val request = createRequest(PlrId, Json.toJson(validRequestBody))
 
     val result = route(app, request).value
@@ -43,7 +75,23 @@ class AmendUKTRControllerSpec extends UKTRDataFixture {
     (jsonResult \ "success" \ "processingDate").asOpt[ZonedDateTime].isDefined mustBe true
   }
 
+  "return UNPROCESSABLE_ENTITY when amendment to a liability return that does not exist" in {
+    when(mockRepository.update(argThat((submission: UKTRSubmission) => submission.isInstanceOf[UKTRLiabilityReturn]), any[String]))
+      .thenReturn(Future.successful(Left(RequestCouldNotBeProcessed)))
+
+    val request = createRequest(PlrId, Json.toJson(validRequestBody))
+
+    val result = route(app, request).value
+    status(result) mustBe UNPROCESSABLE_ENTITY
+    val jsonResult = contentAsJson(result)
+    (jsonResult \ "errors" \ "code").as[String] mustEqual "003"
+    (jsonResult \ "errors" \ "text").as[String] mustEqual "Request could not be processed"
+  }
+
   "return OK with success response for a valid NIL_RETURN amendment" in {
+    when(mockRepository.update(argThat((submission: UKTRSubmission) => submission.isInstanceOf[UKTRNilReturn]), any[String]))
+      .thenReturn(Future.successful(Right(true)))
+
     val request = createRequest(PlrId, nilReturnBody(obligationMTT = false, electionUKGAAP = false))
 
     val result = route(app, request).value
@@ -53,24 +101,17 @@ class AmendUKTRControllerSpec extends UKTRDataFixture {
     (jsonResult \ "success" \ "processingDate").asOpt[ZonedDateTime].isDefined mustBe true
   }
 
-  "return UNPROCESSABLE_ENTITY with tax obligation already met error for specific Pillar2Id" in {
-    val request = createRequest(TaxObligationMetPlrId, Json.toJson(validRequestBody))
+  "return UNPROCESSABLE_ENTITY when amendment to a nil return that does not exist" in {
+    when(mockRepository.update(argThat((submission: UKTRSubmission) => submission.isInstanceOf[UKTRNilReturn]), any[String]))
+      .thenReturn(Future.successful(Left(RequestCouldNotBeProcessed)))
+
+    val request = createRequest(PlrId, nilReturnBody(obligationMTT = false, electionUKGAAP = false))
 
     val result = route(app, request).value
     status(result) mustBe UNPROCESSABLE_ENTITY
     val jsonResult = contentAsJson(result)
-    (jsonResult \ "errors" \ "code").as[String] mustEqual "044"
-    (jsonResult \ "errors" \ "text").as[String] mustEqual "Tax Obligation Already Fulfilled"
-  }
-
-  "return BAD_REQUEST for specific Pillar2Id" in {
-    val request = createRequest(BadRequestPlrId, Json.toJson(validRequestBody))
-
-    val result = route(app, request).value
-    status(result) mustBe BAD_REQUEST
-    val jsonResult = contentAsJson(result)
-    (jsonResult \ "error" \ "code").as[String] mustEqual "400"
-    (jsonResult \ "error" \ "message").as[String] mustEqual "Invalid JSON"
+    (jsonResult \ "errors" \ "code").as[String] mustEqual "003"
+    (jsonResult \ "errors" \ "text").as[String] mustEqual "Request could not be processed"
   }
 
   "return INTERNAL_SERVER_ERROR for specific Pillar2Id" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/StubErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/StubErrorHandlerSpec.scala
@@ -73,7 +73,7 @@ class StubErrorHandlerSpec extends AnyWordSpec with Matchers {
       status(result) shouldBe INTERNAL_SERVER_ERROR
       val json = contentAsJson(result)
       (json \ "code").as[String]    shouldBe "DATABASE_ERROR"
-      (json \ "message").as[String] shouldBe "Database operation failed: Connection failed"
+      (json \ "message").as[String] shouldBe "Connection failed"
     }
 
     "handle unknown errors" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/SubscriptionControllerSpec.scala
@@ -47,8 +47,8 @@ class SubscriptionControllerSpec extends AnyFreeSpec with Matchers with GuiceOne
         status(result) shouldBe FORBIDDEN
       }
 
-      "must return NOT_FOUND for plrReference 'XEPLR0123456404' with SUBSCRIPTION_NOT_FOUND" in {
-        val result = route(app, authorizedRequest("XEPLR0123456404")).value
+      "must return NOT_FOUND for plrReference 'XEPLR5555555554' with SUBSCRIPTION_NOT_FOUND" in {
+        val result = route(app, authorizedRequest("XEPLR5555555554")).value
         status(result)        shouldBe NOT_FOUND
         contentAsJson(result) shouldBe Json.toJson(NotFoundSubscription.response)
       }
@@ -65,22 +65,16 @@ class SubscriptionControllerSpec extends AnyFreeSpec with Matchers with GuiceOne
         contentAsJson(result) shouldBe Json.toJson(ServiceUnavailable503.response)
       }
 
-      "must return OK with detailed success response for domesticOnly=true for plrReference 'XEPLR5555555555'" in {
-        val result = route(app, authorizedRequest("XEPLR5555555555")).value
-        status(result)        shouldBe OK
-        contentAsJson(result) shouldBe Json.toJson(SubscriptionSuccessResponse.successfulDomesticOnlyResponse)
-      }
-
       "must return OK with detailed success response for domesticOnly=false for plrReference 'XEPLR1234567890'" in {
         val result = route(app, authorizedRequest("XEPLR1234567890")).value
         status(result)        shouldBe OK
         contentAsJson(result) shouldBe Json.toJson(SubscriptionSuccessResponse.successfulNonDomesticResponse)
       }
 
-      "must return NOT_FOUND for any other plrReference not explicitly handled" in {
+      "must return OK with detailed success response for domesticOnly=true for any other plrReference" in {
         val result = route(app, authorizedRequest("XEPLR9876543210")).value
-        status(result)        shouldBe NOT_FOUND
-        contentAsJson(result) shouldBe Json.toJson(NotFoundSubscription.response)
+        status(result)        shouldBe OK
+        contentAsJson(result) shouldBe Json.toJson(SubscriptionSuccessResponse.successfulDomesticOnlyResponse)
       }
     }
   }

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/UKTRDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/UKTRDataFixture.scala
@@ -16,17 +16,16 @@
 
 package uk.gov.hmrc.pillar2externalteststub.helpers
 
-import org.scalatest.OptionValues
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.{JsObject, Json}
 import uk.gov.hmrc.http.HeaderNames
+import uk.gov.hmrc.pillar2externalteststub.models.uktr.UKTRSubmission
 
-trait UKTRDataFixture extends AnyFreeSpec with Matchers with GuiceOneAppPerSuite with OptionValues {
+trait UKTRDataFixture {
 
   val authHeader:         (String, String) = HeaderNames.authorisation -> "Bearer valid_token"
   val invalidUKTRAmounts: Seq[BigDecimal]  = Seq(-5, 1e+13, 10.999)
+
+  val pillar2Id = "TEST123"
 
   val validLiableEntity: JsObject = Json.obj(
     "ukChargeableEntityName" -> "New Company",
@@ -98,6 +97,10 @@ trait UKTRDataFixture extends AnyFreeSpec with Matchers with GuiceOneAppPerSuite
         )
       )
   )
+
+  val liabilitySubmission: UKTRSubmission = Json.fromJson[UKTRSubmission](validRequestBody).get
+  val nilSubmission:       UKTRSubmission = Json.fromJson[UKTRSubmission](nilReturnBody(obligationMTT = false, electionUKGAAP = true)).get
+
   val missingUkChargeableEntNameLiableEntity2AndInvalidIdTypeLiableEnt3ReqBody: JsObject = validRequestBody ++ Json.obj(
     "liabilities" -> validRequestBody
       .value("liabilities")

--- a/test/uk/gov/hmrc/pillar2externalteststub/repositories/UKTRSubmissionRepositorySpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/repositories/UKTRSubmissionRepositorySpec.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.repositories
+
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.JsObject
+import play.api.{Application, Configuration}
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+import uk.gov.hmrc.pillar2externalteststub.config.AppConfig
+import uk.gov.hmrc.pillar2externalteststub.helpers.UKTRDataFixture
+import uk.gov.hmrc.pillar2externalteststub.models.uktr.DetailedErrorResponse
+
+import scala.concurrent.ExecutionContext
+
+class UKTRSubmissionRepositorySpec
+    extends AnyWordSpec
+    with Matchers
+    with DefaultPlayMongoRepositorySupport[JsObject]
+    with IntegrationPatience
+    with ScalaFutures
+    with UKTRDataFixture {
+
+  val config = new AppConfig(Configuration.from(Map("appName" -> "pillar2-external-test-stub", "defaultDataExpireInDays" -> 28)))
+  val app: Application = GuiceApplicationBuilder()
+    .overrides(bind[MongoComponent].toInstance(mongoComponent))
+    .build()
+  val repository: UKTRSubmissionRepository =
+    new UKTRSubmissionRepository(config, mongoComponent)(app.injector.instanceOf[ExecutionContext])
+
+  "UKTRSubmissionRepository" when {
+    "handling valid submissions" should {
+      "successfully insert a liability return" in {
+        repository.insert(liabilitySubmission, pillar2Id).futureValue shouldBe true
+      }
+
+      "successfully insert a nil return" in {
+        repository.insert(nilSubmission, pillar2Id).futureValue shouldBe true
+      }
+
+      "successfully handle amendments" in {
+        repository.insert(liabilitySubmission, pillar2Id).futureValue
+
+        repository.update(nilSubmission, pillar2Id).futureValue.isRight shouldBe true
+      }
+    }
+
+    "handling invalid submissions" should {
+      "fail when attempting to update non-existent submission" in {
+        val result: Either[DetailedErrorResponse, Boolean] = repository.update(liabilitySubmission, pillar2Id).futureValue
+
+        result.isLeft shouldBe true
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/pillar2externalteststub/services/OrganisationServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/services/OrganisationServiceSpec.scala
@@ -96,7 +96,7 @@ class OrganisationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
       whenReady(service.createOrganisation(pillar2Id, organisationDetails).failed) { exception =>
         exception                                     shouldBe a[DatabaseError]
         exception.asInstanceOf[DatabaseError].code    shouldBe "DATABASE_ERROR"
-        exception.asInstanceOf[DatabaseError].message shouldBe "Database operation failed: Failed to create organisation: Database connection failed"
+        exception.asInstanceOf[DatabaseError].message shouldBe "Failed to create organisation: Database connection failed"
       }
       verify(mockRepository, times(1)).findByPillar2Id(pillar2Id)
       verify(mockRepository, times(1)).insert(organisationWithId)
@@ -132,7 +132,7 @@ class OrganisationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
       whenReady(service.getOrganisation(pillar2Id).failed) { exception =>
         exception                                     shouldBe a[DatabaseError]
         exception.asInstanceOf[DatabaseError].code    shouldBe "DATABASE_ERROR"
-        exception.asInstanceOf[DatabaseError].message shouldBe "Database operation failed: Failed to find organisation: Database connection failed"
+        exception.asInstanceOf[DatabaseError].message shouldBe "Failed to find organisation: Database connection failed"
       }
       verify(mockRepository, times(1)).findByPillar2Id(pillar2Id)
     }
@@ -160,7 +160,7 @@ class OrganisationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
       whenReady(service.updateOrganisation(pillar2Id, organisationDetails).failed) { exception =>
         exception                                     shouldBe a[DatabaseError]
         exception.asInstanceOf[DatabaseError].code    shouldBe "DATABASE_ERROR"
-        exception.asInstanceOf[DatabaseError].message shouldBe "Database operation failed: Failed to update organisation: Database connection failed"
+        exception.asInstanceOf[DatabaseError].message shouldBe "Failed to update organisation: Database connection failed"
       }
       verify(mockRepository, times(1)).findByPillar2Id(pillar2Id)
       verify(mockRepository, times(1)).update(organisationWithId)
@@ -214,7 +214,7 @@ class OrganisationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
       whenReady(service.deleteOrganisation(pillar2Id).failed) { exception =>
         exception                                     shouldBe a[DatabaseError]
         exception.asInstanceOf[DatabaseError].code    shouldBe "DATABASE_ERROR"
-        exception.asInstanceOf[DatabaseError].message shouldBe "Database operation failed: Failed to delete organisation: Database connection failed"
+        exception.asInstanceOf[DatabaseError].message shouldBe "Failed to delete organisation: Database connection failed"
       }
       verify(mockRepository, times(1)).findByPillar2Id(pillar2Id)
       verify(mockRepository, times(1)).delete(pillar2Id)


### PR DESCRIPTION
### Changes:
- Added a repository for UKTR submissions (UKTRSubmissionsRepository)
- _insert_ and _update_ corresponding to submitUKTR and amendUKTR, respectively

### Result (Submit)
#### Liability return
```json
{
  "_id": "67ae24e073366f26ed006e8d",
  "pillar2Id": "XEPLR5555555555",
  "isAmendment": false,
  "data": {
    "accountingPeriodFrom": "2024-08-14",
    "accountingPeriodTo": "2024-12-14",
    "obligationMTT": false,
    "electionUKGAAP": false,
    "liabilities": {
      "electionDTTSingleMember": false,
      "electionUTPRSingleMember": false,
      "numberSubGroupDTT": 4,
      "numberSubGroupUTPR": 5,
      "totalLiability": 10000.99,
      "totalLiabilityDTT": 5000.99,
      "totalLiabilityIIR": 4000,
      "totalLiabilityUTPR": 10000.99,
      "liableEntities": [
        {
          "ukChargeableEntityName": "New Company",
          "idType": "CRN",
          "idValue": "1234",
          "amountOwedDTT": {
            "$numberLong": "12345678901"
          },
          "amountOwedIIR": 1234567890.09,
          "amountOwedUTPR": 600.5
        }
      ]
    }
  },
  "createdAt": {
    "$date": "2025-02-13T16:59:12.802Z"
  }
}
```

#### Nil return
```json
{
  "_id": "67ae26848fb4132531fe5079",
  "pillar2Id": "XEPLR5555555553",
  "isAmendment": false,
  "data": {
    "accountingPeriodFrom": "2024-09-14",
    "accountingPeriodTo": "2024-11-14",
    "obligationMTT": false,
    "electionUKGAAP": false,
    "liabilities": {
      "returnType": "NIL_RETURN"
    }
  },
  "createdAt": {
    "$date": "2025-02-13T17:06:12.807Z"
  }
}
```

_Amend_ is fairly similar except for `isAmendment` being `true`. We now store all records rather than replace until we decide what we want to do in submission history.