### PR TITLE
PIL-1698: Refactor UKTR to use a typed Mongo model

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/mongo/UKTRMongoSubmission.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/mongo/UKTRMongoSubmission.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.models.uktr.mongo
+
+import org.bson.types.ObjectId
+import play.api.libs.json._
+import uk.gov.hmrc.mongo.play.json.formats.MongoFormats.Implicits._
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats.Implicits._
+import uk.gov.hmrc.pillar2externalteststub.models.uktr.UKTRSubmission
+
+import java.time.Instant
+
+case class UKTRMongoSubmission(_id: ObjectId, pillar2Id: String, isAmendment: Boolean, data: UKTRSubmission, submittedAt: Instant)
+
+object UKTRMongoSubmission {
+  implicit val format: OFormat[UKTRMongoSubmission] = Json.format[UKTRMongoSubmission]
+}

--- a/app/uk/gov/hmrc/pillar2externalteststub/repositories/OrganisationRepository.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/repositories/OrganisationRepository.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.pillar2externalteststub.repositories
 
 import org.bson.conversions.Bson
-import org.mongodb.scala.model.IndexModel
 import org.mongodb.scala.model._
 import play.api.libs.json._
 import uk.gov.hmrc.mongo.MongoComponent

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/UKTRSubmissionISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/UKTRSubmissionISpec.scala
@@ -31,8 +31,10 @@ import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import uk.gov.hmrc.pillar2externalteststub.helpers.UKTRDataFixture
 import uk.gov.hmrc.pillar2externalteststub.helpers.UKTRHelper._
 import uk.gov.hmrc.pillar2externalteststub.models.uktr._
+import uk.gov.hmrc.pillar2externalteststub.models.uktr.mongo.UKTRMongoSubmission
 import uk.gov.hmrc.pillar2externalteststub.repositories.UKTRSubmissionRepository
 
+import java.time.LocalDate
 import scala.concurrent.ExecutionContext
 
 class UKTRSubmissionISpec
@@ -41,7 +43,7 @@ class UKTRSubmissionISpec
     with ScalaFutures
     with IntegrationPatience
     with GuiceOneServerPerSuite
-    with DefaultPlayMongoRepositorySupport[JsObject]
+    with DefaultPlayMongoRepositorySupport[UKTRMongoSubmission]
     with UKTRDataFixture {
 
   override protected val databaseName: String = "test-uktr-submission-integration"
@@ -97,8 +99,8 @@ class UKTRSubmissionISpec
         val response         = amendUKTR(updatedBody, pillar2Id)
         val latestSubmission = repository.findByPillar2Id(pillar2Id).futureValue
 
-        response.status             shouldBe 200
-        latestSubmission.get.toString should include(""""accountingPeriodFrom":"2024-01-01"""")
+        response.status shouldBe 200
+        latestSubmission.get.data.accountingPeriodFrom shouldEqual LocalDate.of(2024, 1, 1)
       }
 
       "return 422 when trying to amend non-existent liability return" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/repositories/UKTRSubmissionRepositorySpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/repositories/UKTRSubmissionRepositorySpec.scala
@@ -21,20 +21,20 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.JsObject
 import play.api.{Application, Configuration}
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import uk.gov.hmrc.pillar2externalteststub.config.AppConfig
 import uk.gov.hmrc.pillar2externalteststub.helpers.UKTRDataFixture
 import uk.gov.hmrc.pillar2externalteststub.models.uktr.DetailedErrorResponse
+import uk.gov.hmrc.pillar2externalteststub.models.uktr.mongo.UKTRMongoSubmission
 
 import scala.concurrent.ExecutionContext
 
 class UKTRSubmissionRepositorySpec
     extends AnyWordSpec
     with Matchers
-    with DefaultPlayMongoRepositorySupport[JsObject]
+    with DefaultPlayMongoRepositorySupport[UKTRMongoSubmission]
     with IntegrationPatience
     with ScalaFutures
     with UKTRDataFixture {


### PR DESCRIPTION
### Changes
- Replaced JsObject with typed UKTRMongoSubmission model for better type safety
- Renamed `createdAt` field to `submittedAt` for consistency with BTN
- Updated index structure to include compound index on `pillar2Id` and `submittedAt`