### PR TITLE
PIL-1644: Clear submission data upon testOrg deletion

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/repositories/BTNSubmissionRepository.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/repositories/BTNSubmissionRepository.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.pillar2externalteststub.repositories
 
+import org.mongodb.scala.model.Filters.equal
 import org.mongodb.scala.model._
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
@@ -72,4 +73,10 @@ class BTNSubmissionRepository @Inject() (
       .recoverWith { case e: Exception =>
         Future.failed(DatabaseError(s"Failed to retrieve BTN submissions: ${e.getMessage}"))
       }
+
+  def deleteByPillar2Id(pillar2Id: String): Future[Boolean] =
+    collection
+      .deleteMany(equal("pillar2Id", pillar2Id))
+      .toFuture()
+      .map(_.wasAcknowledged())
 }

--- a/app/uk/gov/hmrc/pillar2externalteststub/repositories/UKTRSubmissionRepository.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/repositories/UKTRSubmissionRepository.scala
@@ -87,4 +87,10 @@ class UKTRSubmissionRepository @Inject() (config: AppConfig, mongoComponent: Mon
       .find(equal("pillar2Id", pillar2Id))
       .sort(descending("submittedAt"))
       .headOption()
+
+  def deleteByPillar2Id(pillar2Id: String): Future[Boolean] =
+    collection
+      .deleteMany(equal("pillar2Id", pillar2Id))
+      .toFuture()
+      .map(_.wasAcknowledged())
 }

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/BTNControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/BTNControllerSpec.scala
@@ -62,7 +62,7 @@ class BTNControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSui
       "should return UNPROCESSABLE_ENTITY when X-Pillar2-Id header is missing" in {
         val request = FakeRequest(POST, "/RESTAdapter/PLR/below-threshold-notification")
           .withHeaders("Content-Type" -> "application/json", authHeader)
-          .withBody(validRequestBody)
+          .withBody(validBTNRequestBody)
 
         val result = route(app, request).get
         status(result) shouldBe UNPROCESSABLE_ENTITY

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/BTNDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/BTNDataFixture.scala
@@ -28,14 +28,12 @@ import java.time.Instant
 
 trait BTNDataFixture extends Pillar2DataFixture {
 
-  val authHeader: (String, String) = HeaderNames.AUTHORIZATION -> "Bearer token"
-
   val validBTNRequest: BTNRequest = BTNRequest(
     accountingPeriodFrom = accountingPeriod.startDate,
     accountingPeriodTo = accountingPeriod.endDate
   )
 
-  val validRequestBody: JsValue = Json.toJson(validBTNRequest)
+  val validBTNRequestBody: JsValue = Json.toJson(validBTNRequest)
 
   val BTNMongoSubmission: BTNSubmission = BTNSubmission(
     _id = new ObjectId(),

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/Pillar2DataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/Pillar2DataFixture.scala
@@ -16,11 +16,14 @@
 
 package uk.gov.hmrc.pillar2externalteststub.helpers
 
+import uk.gov.hmrc.http.HeaderNames
 import uk.gov.hmrc.pillar2externalteststub.models.organisation.AccountingPeriod
 
 import java.time.LocalDate
 
 trait Pillar2DataFixture {
+
+  val authHeader: (String, String) = HeaderNames.authorisation -> "Bearer valid_token"
 
   val validPlrId       = "XMPLR0000000000"
   val nonDomesticPlrId = "XEPLR1234567890"

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/UKTRDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/UKTRDataFixture.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.pillar2externalteststub.helpers
 
 import org.bson.types.ObjectId
 import play.api.libs.json.{JsObject, Json}
-import uk.gov.hmrc.http.HeaderNames
 import uk.gov.hmrc.pillar2externalteststub.models.organisation._
 import uk.gov.hmrc.pillar2externalteststub.models.uktr.UKTRSubmission
 import uk.gov.hmrc.pillar2externalteststub.models.uktr.mongo.UKTRMongoSubmission
@@ -28,8 +27,7 @@ import java.time.LocalDate
 
 trait UKTRDataFixture extends Pillar2DataFixture {
 
-  val authHeader:         (String, String) = HeaderNames.authorisation -> "Bearer valid_token"
-  val invalidUKTRAmounts: Seq[BigDecimal]  = Seq(-5, 1e+13, 10.999)
+  val invalidUKTRAmounts: Seq[BigDecimal] = Seq(-5, 1e+13, 10.999)
 
   val validLiableEntity: JsObject = Json.obj(
     "ukChargeableEntityName" -> "New Company",

--- a/test/uk/gov/hmrc/pillar2externalteststub/repositories/BTNSubmissionRepositorySpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/repositories/BTNSubmissionRepositorySpec.scala
@@ -133,4 +133,21 @@ class BTNSubmissionRepositorySpec
       submissions.map(_.accountingPeriodFrom) should contain theSameElementsAs requests.map(_.accountingPeriodFrom)
     }
   }
+
+  "deleteByPillar2Id" should {
+    "successfully delete all submissions for a given pillar2Id" in {
+      repository.insert(testPillar2Id, testRequest).futureValue
+      repository.insert(testPillar2Id, testRequest).futureValue
+
+      repository.findByPillar2Id(testPillar2Id).futureValue.size shouldBe 2
+
+      repository.deleteByPillar2Id(testPillar2Id).futureValue shouldBe true
+      repository.findByPillar2Id(testPillar2Id).futureValue   shouldBe empty
+    }
+
+    "return true when attempting to delete non-existent pillar2Id" in {
+      val deleteResult = repository.deleteByPillar2Id("NONEXISTENT").futureValue
+      deleteResult shouldBe true
+    }
+  }
 }

--- a/test/uk/gov/hmrc/pillar2externalteststub/repositories/UKTRSubmissionRepositorySpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/repositories/UKTRSubmissionRepositorySpec.scala
@@ -70,5 +70,22 @@ class UKTRSubmissionRepositorySpec
         result.isLeft shouldBe true
       }
     }
+
+    "handling deletions" should {
+      "successfully delete all submissions for a given pillar2Id" in {
+        repository.insert(liabilitySubmission, validPlrId).futureValue
+        repository.insert(nilSubmission, validPlrId, isAmendment = true).futureValue
+
+        repository.findByPillar2Id(validPlrId).futureValue.isDefined shouldBe true
+
+        repository.deleteByPillar2Id(validPlrId).futureValue         shouldBe true
+        repository.findByPillar2Id(validPlrId).futureValue.isDefined shouldBe false
+      }
+
+      "return true when attempting to delete non-existent pillar2Id" in {
+        val deleteResult = repository.deleteByPillar2Id("NONEXISTENT").futureValue
+        deleteResult shouldBe true
+      }
+    }
   }
 }


### PR DESCRIPTION
### Changes:
- Enabled deletion by `pillar2Id` in both _UKTR_ and _BTN_ collections
- Added side effects to `testOrg/DELETE` to wipe records in the two collections