### PR TITLE
PIL-1629 - Add ORN endpoints

### DIFF
--- a/API Testing/02-orn/Amend ORN - valid request.bru
+++ b/API Testing/02-orn/Amend ORN - valid request.bru
@@ -1,0 +1,48 @@
+meta {
+  name: Amend ORN - Valid Request
+  type: http
+  seq: 2
+}
+
+put {
+  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{nonDomesticPlrId}}
+  Authorization: validBearerToken
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2024-12-31",
+    "filedDateGIR": "2025-01-10",
+    "countryGIR": "US",
+    "reportingEntityName": "Newco PLC",
+    "TIN": "US12345678",
+    "issuingCountryTIN": "US"
+  }
+}
+
+tests {
+  test("should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+  
+  test("should contain form bundle number", function() {
+    expect(res.body.success.formBundleNumber).to.not.be.undefined;
+  });
+  
+  test("should contain processing date", function() {
+    expect(res.body.success.processingDate).to.not.be.undefined;
+  });
+  
+  test("response should have proper content structure", function() {
+    expect(res.body).to.have.property("success");
+    expect(res.body.success).to.be.an("object");
+  });
+} 

--- a/API Testing/02-orn/Get ORN - no submission.bru
+++ b/API Testing/02-orn/Get ORN - no submission.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Get ORN - No Submission Found
+  type: http
+  seq: 11
+}
+
+get {
+  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification?accountingPeriodFrom=2025-01-01&accountingPeriodTo=2025-12-31
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{nonDomesticPlrId}}
+  Authorization: validBearerToken
+}
+
+tests {
+  test("should return 422", function() {
+    expect(res.status).to.equal(422);
+  });
+  
+  test("should include error details about no submission found", function() {
+    expect(res.body.errors).to.not.be.undefined;
+    expect(res.body.errors.code).to.equal("003");
+    expect(res.body.errors.text).to.include("Request could not be processed");
+  });
+}
+
+docs {
+  Note: "This test uses a different accounting period (2025) than what would normally be submitted to ensure no matching records are found."
+} 

--- a/API Testing/02-orn/Get ORN - valid request.bru
+++ b/API Testing/02-orn/Get ORN - valid request.bru
@@ -1,0 +1,42 @@
+meta {
+  name: Get ORN - Valid Request
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification?accountingPeriodFrom=2024-01-01&accountingPeriodTo=2024-12-31
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{nonDomesticPlrId}}
+  Authorization: validBearerToken
+}
+
+tests {
+  test("should return 200 OK", function() {
+    expect(res.status).to.equal(200);
+  });
+  
+  test("should have correct response structure", function() {
+    expect(res.body).to.have.property("success");
+    expect(res.body.success).to.be.an("object");
+  });
+  
+  test("should include required fields", function() {
+    expect(res.body.success).to.have.property("processingDate");
+    expect(res.body.success).to.have.property("accountingPeriodFrom");
+    expect(res.body.success).to.have.property("accountingPeriodTo");
+    expect(res.body.success).to.have.property("filedDateGIR");
+    expect(res.body.success).to.have.property("countryGIR");
+    expect(res.body.success).to.have.property("reportingEntityName");
+    expect(res.body.success).to.have.property("TIN");
+    expect(res.body.success).to.have.property("issuingCountryTIN");
+  });
+  
+  test("should have matching accounting period dates", function() {
+    expect(res.body.success.accountingPeriodFrom).to.equal("2024-01-01");
+    expect(res.body.success.accountingPeriodTo).to.equal("2024-12-31");
+  });
+}

--- a/API Testing/02-orn/Submit ORN - 500 pillarId.bru
+++ b/API Testing/02-orn/Submit ORN - 500 pillarId.bru
@@ -1,0 +1,41 @@
+meta {
+  name: Submit ORN - Server Error
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{serverErrorPillar2Id}}
+  Authorization: validBearerToken
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2024-12-31",
+    "filedDateGIR": "2025-01-10",
+    "countryGIR": "US",
+    "reportingEntityName": "Newco PLC",
+    "TIN": "US12345678",
+    "issuingCountryTIN": "US"
+  }
+}
+
+tests {
+  test("should return 500 Server Error", function() {
+    expect(res.status).to.equal(500);
+  });
+  
+  test("should include error details", function() {
+    expect(res.body.errors).to.not.be.undefined;
+    expect(res.body.errors.code).to.equal("500");
+    expect(res.body.errors.text).to.include("Internal server error");
+  });
+}

--- a/API Testing/02-orn/Submit ORN - duplicate submission.bru
+++ b/API Testing/02-orn/Submit ORN - duplicate submission.bru
@@ -1,0 +1,45 @@
+meta {
+  name: Submit ORN - Duplicate Submission
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{nonDomesticPlrId}}
+  Authorization: validBearerToken
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2024-12-31",
+    "filedDateGIR": "2025-01-10",
+    "countryGIR": "US",
+    "reportingEntityName": "Newco PLC",
+    "TIN": "US12345678",
+    "issuingCountryTIN": "US"
+  }
+}
+
+tests {
+  test("should return 422 for duplicate submission", function() {
+    expect(res.status).to.equal(422);
+  });
+  
+  test("should contain error about tax obligation already fulfilled", function() {
+    expect(res.body.errors).to.not.be.undefined;
+    expect(res.body.errors.code).to.equal("044");
+    expect(res.body.errors.text).to.include("Tax obligation already fulfilled");
+  });
+}
+
+docs {
+  Note: "This test needs to be run after a successful submission with the same accounting period. The first submission should return 201, but running it again with the same data should trigger this 422 error."
+} 

--- a/API Testing/02-orn/Submit ORN - invalid date.bru
+++ b/API Testing/02-orn/Submit ORN - invalid date.bru
@@ -1,0 +1,40 @@
+meta {
+  name: Submit ORN - Invalid Date Format
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{nonDomesticPlrId}}
+  Authorization: validBearerToken
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-001-01",
+    "accountingPeriodTo": "2024-12-31",
+    "filedDateGIR": "2025-01-10",
+    "countryGIR": "US",
+    "reportingEntityName": "Newco PLC",
+    "TIN": "US12345678",
+    "issuingCountryTIN": "US"
+  }
+}
+
+tests {
+  test("should return 400 for invalid date format", function() {
+    expect(res.status).to.equal(400);
+  });
+  
+  test("should contain error about invalid date format", function() {
+    expect(res.body.errors).to.not.be.undefined;
+    expect(res.body.errors.code).to.equal("400");
+  });
+} 

--- a/API Testing/02-orn/Submit ORN - invalid json.bru
+++ b/API Testing/02-orn/Submit ORN - invalid json.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Submit ORN - Invalid JSON
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{nonDomesticPlrId}}
+  Authorization: validBearerToken
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2024-12-31"
+    invalid_json_here
+    "filedDateGIR": "2025-01-10",
+    "countryGIR": "US",
+    "reportingEntityName": "Newco PLC",
+    "TIN": "US12345678",
+    "issuingCountryTIN": "US"
+  }
+}
+
+tests {
+  test("should return 400 for invalid JSON", function() {
+    expect(res.status).to.equal(400);
+  });
+}

--- a/API Testing/02-orn/Submit ORN - missing header.bru
+++ b/API Testing/02-orn/Submit ORN - missing header.bru
@@ -1,0 +1,40 @@
+meta {
+  name: Submit ORN - Missing Pillar2-ID Header
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  Authorization: validBearerToken
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2024-12-31",
+    "filedDateGIR": "2025-01-10",
+    "countryGIR": "US",
+    "reportingEntityName": "Newco PLC",
+    "TIN": "US12345678",
+    "issuingCountryTIN": "US"
+  }
+}
+
+tests {
+  test("should return 422 when X-Pillar2-Id header is missing", function() {
+    expect(res.status).to.equal(422);
+  });
+  
+  test("should include error details about missing Pillar2-ID", function() {
+    expect(res.body.errors).to.not.be.undefined;
+    expect(res.body.errors.code).to.equal("002");
+    expect(res.body.errors.text).to.include("Pillar2 ID Missing or Invalid");
+  });
+} 

--- a/API Testing/02-orn/Submit ORN - unauthorized.bru
+++ b/API Testing/02-orn/Submit ORN - unauthorized.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Submit ORN - Unauthorized
+  type: http
+  seq: 7
+}
+
+post {
+  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{nonDomesticPlrId}}
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2024-12-31",
+    "filedDateGIR": "2025-01-10",
+    "countryGIR": "US",
+    "reportingEntityName": "Newco PLC",
+    "TIN": "US12345678",
+    "issuingCountryTIN": "US"
+  }
+}
+
+tests {
+  test("should return 403 when no authorization token provided", function() {
+    expect(res.status).to.equal(403);
+  });
+} 

--- a/API Testing/02-orn/Submit ORN - valid request.bru
+++ b/API Testing/02-orn/Submit ORN - valid request.bru
@@ -1,0 +1,48 @@
+meta {
+  name: Submit ORN - Valid Request
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+  X-Pillar2-Id: {{nonDomesticPlrId}}
+  Authorization: validBearerToken
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2024-12-31",
+    "filedDateGIR": "2025-01-10",
+    "countryGIR": "US",
+    "reportingEntityName": "Newco PLC",
+    "TIN": "US12345678",
+    "issuingCountryTIN": "US"
+  }
+}
+
+tests {
+  test("should return 201 Created", function() {
+    expect(res.status).to.equal(201);
+  });
+  
+  test("should contain form bundle number", function() {
+    expect(res.body.success.formBundleNumber).to.not.be.undefined;
+  });
+  
+  test("should contain processing date", function() {
+    expect(res.body.success.processingDate).to.not.be.undefined;
+  });
+  
+  test("response should have proper content structure", function() {
+    expect(res.body).to.have.property("success");
+    expect(res.body.success).to.be.an("object");
+  });
+}

--- a/API Testing/bruno.json
+++ b/API Testing/bruno.json
@@ -24,6 +24,10 @@
       "path": "02-btn"
     },
     {
+      "name": "Overseas Return Notification",
+      "path": "02-orn"
+    },
+    {
       "name": "Cleanup",
       "path": "09-cleanup"
     }

--- a/API Testing/environments/local.bru
+++ b/API Testing/environments/local.bru
@@ -4,4 +4,5 @@ vars {
   testPlrId: XEPLR1234567890
   domesticOnlyPlrId: XEPLR5555555555
   nonDomesticPlrId: XEPLR6666666666
+  serverErrorPillar2Id: XEPLR5000000000
 }

--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/ORNController.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/ORNController.scala
@@ -99,7 +99,7 @@ class ORNController @Inject() (
       } catch {
         case e: DateTimeParseException =>
           logger.error(s"Invalid date format: ${e.getMessage}")
-          Future.failed(RequestCouldNotBeProcessed)
+          Future.failed(ETMPBadRequest)
       }
     }
   }

--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/ORNController.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/ORNController.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.controllers
+
+import play.api.Logging
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.pillar2externalteststub.controllers.actions.AuthActionFilter
+import uk.gov.hmrc.pillar2externalteststub.helpers.Pillar2Helper.{ServerErrorPlrId, pillar2Regex}
+import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError._
+import uk.gov.hmrc.pillar2externalteststub.models.error.OrganisationNotFound
+import uk.gov.hmrc.pillar2externalteststub.models.orn.ORNSuccessResponse.{ORN_SUCCESS_200, ORN_SUCCESS_201}
+import uk.gov.hmrc.pillar2externalteststub.models.orn.{ORNGetResponse, ORNRequest}
+import uk.gov.hmrc.pillar2externalteststub.repositories.ORNSubmissionRepository
+import uk.gov.hmrc.pillar2externalteststub.services.{ORNService, OrganisationService}
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class ORNController @Inject() (
+  cc:                  ControllerComponents,
+  authFilter:          AuthActionFilter,
+  ornService:          ORNService,
+  repository:          ORNSubmissionRepository,
+  organisationService: OrganisationService
+)(implicit ec:         ExecutionContext)
+    extends BackendController(cc)
+    with Logging {
+
+  def submitORN: Action[JsValue] = (Action(parse.json) andThen authFilter).async { implicit request =>
+    validatePillar2Id(request.headers.get("X-Pillar2-Id")).flatMap(checkForServerErrorId).flatMap { pillar2Id =>
+      request.body
+        .validate[ORNRequest]
+        .fold(
+          _ => Future.failed(ETMPBadRequest),
+          ornRequest =>
+            organisationService
+              .getOrganisation(pillar2Id)
+              .flatMap(_ => ornService.submitORN(pillar2Id, ornRequest))
+              .map(_ => Created(Json.toJson(ORN_SUCCESS_201)))
+              .recoverWith { case _: OrganisationNotFound =>
+                Future.failed(NoActiveSubscription)
+              }
+        )
+    }
+  }
+
+  def amendORN: Action[JsValue] = (Action(parse.json) andThen authFilter).async { implicit request =>
+    validatePillar2Id(request.headers.get("X-Pillar2-Id")).flatMap(checkForServerErrorId).flatMap { pillar2Id =>
+      request.body
+        .validate[ORNRequest]
+        .fold(
+          _ => Future.failed(ETMPBadRequest),
+          ornRequest =>
+            organisationService
+              .getOrganisation(pillar2Id)
+              .flatMap(_ => ornService.amendORN(pillar2Id, ornRequest))
+              .map(_ => Ok(Json.toJson(ORN_SUCCESS_200)))
+              .recoverWith { case _: OrganisationNotFound =>
+                Future.failed(NoActiveSubscription)
+              }
+        )
+    }
+  }
+
+  def getORN(accountingPeriodFrom: String, accountingPeriodTo: String): Action[AnyContent] = (Action andThen authFilter).async { implicit request =>
+    validatePillar2Id(request.headers.get("X-Pillar2-Id")).flatMap(checkForServerErrorId).flatMap { pillar2Id =>
+      try {
+        val fromDate = LocalDate.parse(accountingPeriodFrom)
+        val toDate   = LocalDate.parse(accountingPeriodTo)
+
+        ornService
+          .getORN(pillar2Id, fromDate, toDate)
+          .flatMap {
+            case Some(submission) => Future.successful(Ok(Json.toJson(ORNGetResponse.fromSubmission(submission))))
+            case None             => Future.failed(RequestCouldNotBeProcessed)
+          }
+          .recoverWith { case _: OrganisationNotFound =>
+            Future.failed(NoActiveSubscription)
+          }
+      } catch {
+        case e: DateTimeParseException =>
+          logger.error(s"Invalid date format: ${e.getMessage}")
+          Future.failed(RequestCouldNotBeProcessed)
+      }
+    }
+  }
+
+  private def validatePillar2Id(pillar2Id: Option[String]): Future[String] =
+    pillar2Id match {
+      case Some(id) if pillar2Regex.matches(id) =>
+        logger.info(s"Valid Pillar2Id received: $id")
+        Future.successful(id)
+      case other =>
+        logger.warn(s"Invalid Pillar2Id received: $other")
+        Future.failed(Pillar2IdMissing)
+    }
+
+  private def checkForServerErrorId(pillar2Id: String): Future[String] =
+    if (pillar2Id == ServerErrorPlrId) {
+      logger.warn("Server error triggered by special PLR ID")
+      Future.failed(ETMPInternalServerError)
+    } else {
+      Future.successful(pillar2Id)
+    }
+}

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNGetResponse.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNGetResponse.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.models.orn
+
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.pillar2externalteststub.models.orn.mongo.ORNSubmission
+
+import java.time.temporal.ChronoUnit
+import java.time.{LocalDate, ZoneOffset, ZonedDateTime}
+
+case class ORNGetResponse(success: ORNGetSuccess)
+
+object ORNGetResponse {
+  implicit val format: OFormat[ORNGetResponse] = Json.format[ORNGetResponse]
+
+  def fromSubmission(submission: ORNSubmission): ORNGetResponse = ORNGetResponse(
+    success = ORNGetSuccess(
+      processingDate = ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS),
+      accountingPeriodFrom = submission.accountingPeriodFrom,
+      accountingPeriodTo = submission.accountingPeriodTo,
+      filedDateGIR = submission.filedDateGIR,
+      countryGIR = submission.countryGIR,
+      reportingEntityName = submission.reportingEntityName,
+      TIN = submission.TIN,
+      issuingCountryTIN = submission.issuingCountryTIN
+    )
+  )
+}
+
+case class ORNGetSuccess(
+  processingDate:       ZonedDateTime,
+  accountingPeriodFrom: LocalDate,
+  accountingPeriodTo:   LocalDate,
+  filedDateGIR:         LocalDate,
+  countryGIR:           String,
+  reportingEntityName:  String,
+  TIN:                  String,
+  issuingCountryTIN:    String
+)
+
+object ORNGetSuccess {
+  implicit val format: OFormat[ORNGetSuccess] = Json.format[ORNGetSuccess]
+}

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNRequest.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNRequest.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.models.orn
+
+import play.api.libs.json.{Json, OFormat}
+
+import java.time.LocalDate
+
+case class ORNRequest(
+  accountingPeriodFrom: LocalDate,
+  accountingPeriodTo:   LocalDate,
+  filedDateGIR:         LocalDate,
+  countryGIR:           String,
+  reportingEntityName:  String,
+  TIN:                  String,
+  issuingCountryTIN:    String
+) {
+  def accountingPeriodValid: Boolean =
+    accountingPeriodFrom.isBefore(accountingPeriodTo)
+}
+
+object ORNRequest {
+  implicit val format: OFormat[ORNRequest] = Json.format[ORNRequest]
+}

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNResponse.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNResponse.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.models.orn
+
+import play.api.libs.json.{Json, OFormat}
+
+import java.time.temporal.ChronoUnit
+import java.time.{ZoneOffset, ZonedDateTime}
+
+trait ORNResponse
+
+object ORNResponse {
+  def now: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS)
+}
+
+case class ORNSuccessResponse(success: ORNSuccess) extends ORNResponse
+
+object ORNSuccessResponse {
+  implicit val format: OFormat[ORNSuccessResponse] = Json.format[ORNSuccessResponse]
+
+  def ORN_SUCCESS_201: ORNSuccessResponse = ORNSuccessResponse(
+    ORNSuccess(
+      processingDate = ORNResponse.now,
+      formBundleNumber = generateFormBundleNumber()
+    )
+  )
+
+  def ORN_SUCCESS_200: ORNSuccessResponse = ORNSuccessResponse(
+    ORNSuccess(
+      processingDate = ORNResponse.now,
+      formBundleNumber = generateFormBundleNumber()
+    )
+  )
+
+  private def generateFormBundleNumber(): String = {
+    val random = new scala.util.Random
+    f"${119000000000L + random.nextInt(999999)}%012d"
+  }
+}
+
+case class ORNSuccess(processingDate: ZonedDateTime, formBundleNumber: String)
+
+object ORNSuccess {
+  implicit val format: OFormat[ORNSuccess] = Json.format[ORNSuccess]
+}

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/orn/mongo/ORNSubmission.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/orn/mongo/ORNSubmission.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.models.orn.mongo
+
+import org.bson.types.ObjectId
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+import uk.gov.hmrc.mongo.play.json.formats.MongoFormats
+import uk.gov.hmrc.pillar2externalteststub.models.orn.ORNRequest
+
+import java.time.Instant
+import java.time.LocalDate
+
+case class ORNSubmission(
+  _id:                  ObjectId,
+  pillar2Id:            String,
+  accountingPeriodFrom: LocalDate,
+  accountingPeriodTo:   LocalDate,
+  filedDateGIR:         LocalDate,
+  countryGIR:           String,
+  reportingEntityName:  String,
+  TIN:                  String,
+  issuingCountryTIN:    String,
+  submittedAt:          Instant
+)
+
+object ORNSubmission {
+
+  def fromRequest(pillar2Id: String, request: ORNRequest): ORNSubmission =
+    ORNSubmission(
+      _id = new ObjectId(),
+      pillar2Id = pillar2Id,
+      accountingPeriodFrom = request.accountingPeriodFrom,
+      accountingPeriodTo = request.accountingPeriodTo,
+      filedDateGIR = request.filedDateGIR,
+      countryGIR = request.countryGIR,
+      reportingEntityName = request.reportingEntityName,
+      TIN = request.TIN,
+      issuingCountryTIN = request.issuingCountryTIN,
+      submittedAt = Instant.now()
+    )
+
+  private val mongoInstantFormat: Format[Instant] = new Format[Instant] {
+
+    override def writes(instant: Instant): JsValue = Json.obj(
+      "$date" -> Json.obj(
+        "$numberLong" -> instant.toEpochMilli.toString
+      )
+    )
+
+    override def reads(json: JsValue): JsResult[Instant] = json match {
+      case obj: JsObject if (obj \ "$date" \ "$numberLong").isDefined =>
+        (obj \ "$date" \ "$numberLong").get.validate[String].map(s => Instant.ofEpochMilli(s.toLong))
+      case _ => JsError("Expected MongoDB date format")
+    }
+  }
+
+  // MongoDB format for storage
+  private val mongoReads: Reads[ORNSubmission] =
+    (
+      (__ \ "_id").read[ObjectId](MongoFormats.objectIdFormat) and
+        (__ \ "pillar2Id").read[String] and
+        (__ \ "accountingPeriodFrom").read[LocalDate] and
+        (__ \ "accountingPeriodTo").read[LocalDate] and
+        (__ \ "filedDateGIR").read[LocalDate] and
+        (__ \ "countryGIR").read[String] and
+        (__ \ "reportingEntityName").read[String] and
+        (__ \ "TIN").read[String] and
+        (__ \ "issuingCountryTIN").read[String] and
+        (__ \ "submittedAt").read[Instant](mongoInstantFormat)
+    )(ORNSubmission.apply _)
+
+  private val mongoWrites: OWrites[ORNSubmission] =
+    (
+      (__ \ "_id").write[ObjectId](MongoFormats.objectIdFormat) and
+        (__ \ "pillar2Id").write[String] and
+        (__ \ "accountingPeriodFrom").write[LocalDate] and
+        (__ \ "accountingPeriodTo").write[LocalDate] and
+        (__ \ "filedDateGIR").write[LocalDate] and
+        (__ \ "countryGIR").write[String] and
+        (__ \ "reportingEntityName").write[String] and
+        (__ \ "TIN").write[String] and
+        (__ \ "issuingCountryTIN").write[String] and
+        (__ \ "submittedAt").write[Instant](mongoInstantFormat)
+    )(unlift(ORNSubmission.unapply))
+
+  val mongoFormat: OFormat[ORNSubmission] = OFormat(mongoReads, mongoWrites)
+}

--- a/app/uk/gov/hmrc/pillar2externalteststub/repositories/ORNSubmissionRepository.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/repositories/ORNSubmissionRepository.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.repositories
+
+import org.mongodb.scala.model._
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+import uk.gov.hmrc.pillar2externalteststub.config.AppConfig
+import uk.gov.hmrc.pillar2externalteststub.models.error.DatabaseError
+import uk.gov.hmrc.pillar2externalteststub.models.orn.ORNRequest
+import uk.gov.hmrc.pillar2externalteststub.models.orn.mongo.ORNSubmission
+
+import java.time.LocalDate
+import java.util.concurrent.TimeUnit
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class ORNSubmissionRepository @Inject() (
+  mongoComponent: MongoComponent,
+  config:         AppConfig
+)(implicit ec:    ExecutionContext)
+    extends PlayMongoRepository[ORNSubmission](
+      collectionName = "orn-submissions",
+      mongoComponent = mongoComponent,
+      domainFormat = ORNSubmission.mongoFormat,
+      indexes = Seq(
+        IndexModel(
+          Indexes.ascending("_id"),
+          IndexOptions()
+            .name("idIndex")
+        ),
+        IndexModel(
+          Indexes.ascending("pillar2Id"),
+          IndexOptions().name("pillar2IdIndex")
+        ),
+        IndexModel(
+          Indexes.compoundIndex(
+            Indexes.ascending("pillar2Id"),
+            Indexes.ascending("accountingPeriodFrom"),
+            Indexes.ascending("accountingPeriodTo")
+          ),
+          IndexOptions().name("pillar2Id_accountingPeriod_idx")
+        ),
+        IndexModel(
+          Indexes.ascending("submittedAt"),
+          IndexOptions()
+            .name("submittedAtTTL")
+            .expireAfter(config.defaultDataExpireInDays, TimeUnit.DAYS)
+        )
+      )
+    ) {
+
+  def insert(pillar2Id: String, submission: ORNRequest): Future[Boolean] =
+    collection
+      .insertOne(ORNSubmission.fromRequest(pillar2Id, submission))
+      .toFuture()
+      .map(_ => true)
+      .recoverWith { case e: Exception =>
+        Future.failed(DatabaseError(s"Failed to save ORN submission: ${e.getMessage}"))
+      }
+
+  def findByPillar2Id(pillar2Id: String): Future[Seq[ORNSubmission]] =
+    collection
+      .find(Filters.equal("pillar2Id", pillar2Id))
+      .toFuture()
+      .recoverWith { case e: Exception =>
+        Future.failed(DatabaseError(s"Failed to retrieve ORN submissions: ${e.getMessage}"))
+      }
+
+  def findByPillar2IdAndAccountingPeriod(
+    pillar2Id:            String,
+    accountingPeriodFrom: LocalDate,
+    accountingPeriodTo:   LocalDate
+  ): Future[Option[ORNSubmission]] =
+    collection
+      .find(
+        Filters.and(
+          Filters.equal("pillar2Id", pillar2Id),
+          Filters.equal("accountingPeriodFrom", accountingPeriodFrom.toString),
+          Filters.equal("accountingPeriodTo", accountingPeriodTo.toString)
+        )
+      )
+      .sort(Sorts.descending("submittedAt"))
+      .headOption()
+      .recoverWith { case e: Exception =>
+        Future.failed(DatabaseError(s"Failed to retrieve ORN submission: ${e.getMessage}"))
+      }
+
+  def deleteByPillar2Id(pillar2Id: String): Future[Boolean] =
+    collection
+      .deleteMany(Filters.equal("pillar2Id", pillar2Id))
+      .toFuture()
+      .map(_ => true)
+      .recoverWith { case e: Exception => Future.failed(DatabaseError(s"Failed to delete ORN submission: ${e.getMessage}")) }
+}

--- a/app/uk/gov/hmrc/pillar2externalteststub/repositories/OrganisationRepository.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/repositories/OrganisationRepository.scala
@@ -35,7 +35,8 @@ class OrganisationRepository @Inject() (
   config:         AppConfig,
   btnRepository:  BTNSubmissionRepository,
   uktrRepository: UKTRSubmissionRepository,
-  oasRepository:  ObligationsAndSubmissionsRepository
+  oasRepository:  ObligationsAndSubmissionsRepository,
+  ornRepository:  ORNSubmissionRepository
 )(implicit ec:    ExecutionContext)
     extends PlayMongoRepository[TestOrganisationWithId](
       collectionName = "organisation",
@@ -101,6 +102,7 @@ class OrganisationRepository @Inject() (
     for {
       _         <- uktrRepository.deleteByPillar2Id(pillar2Id)
       _         <- btnRepository.deleteByPillar2Id(pillar2Id)
+      _         <- ornRepository.deleteByPillar2Id(pillar2Id)
       _         <- oasRepository.deleteByPillar2Id(pillar2Id)
       deleteOrg <- collection.deleteOne(byPillar2Id(pillar2Id)).toFuture()
     } yield deleteOrg.wasAcknowledged()

--- a/app/uk/gov/hmrc/pillar2externalteststub/services/ORNService.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/services/ORNService.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.services
+
+import play.api.Logging
+import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.{RequestCouldNotBeProcessed, TaxObligationAlreadyFulfilled}
+import uk.gov.hmrc.pillar2externalteststub.models.orn.ORNRequest
+import uk.gov.hmrc.pillar2externalteststub.models.orn.mongo.ORNSubmission
+import uk.gov.hmrc.pillar2externalteststub.repositories.ORNSubmissionRepository
+
+import java.time.LocalDate
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class ORNService @Inject() (
+  repository:  ORNSubmissionRepository
+)(implicit ec: ExecutionContext)
+    extends Logging {
+
+  def submitORN(pillar2Id: String, request: ORNRequest): Future[Boolean] =
+    repository.findByPillar2Id(pillar2Id).flatMap { submissions =>
+      if (
+        submissions.exists(submission =>
+          submission.accountingPeriodFrom == request.accountingPeriodFrom && submission.accountingPeriodTo == request.accountingPeriodTo
+        )
+      ) {
+        logger.warn(s"Tax obligation already fulfilled for pillar2Id: $pillar2Id")
+        Future.failed(TaxObligationAlreadyFulfilled)
+      } else {
+        logger.info(s"Submitting new ORN for pillar2Id: $pillar2Id")
+        repository.insert(pillar2Id, request)
+      }
+    }
+
+  def amendORN(pillar2Id: String, request: ORNRequest): Future[Boolean] =
+    repository.findByPillar2Id(pillar2Id).flatMap { submissions =>
+      if (submissions.isEmpty) {
+        logger.warn(s"No existing ORN found for pillar2Id: $pillar2Id")
+        Future.failed(RequestCouldNotBeProcessed)
+      } else {
+        logger.info(s"Amending ORN for pillar2Id: $pillar2Id")
+        repository.insert(pillar2Id, request)
+      }
+    }
+
+  def getORN(pillar2Id: String, accountingPeriodFrom: LocalDate, accountingPeriodTo: LocalDate): Future[Option[ORNSubmission]] =
+    repository
+      .findByPillar2IdAndAccountingPeriod(pillar2Id, accountingPeriodFrom, accountingPeriodTo)
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -8,6 +8,9 @@ PUT         /RESTAdapter/PLR/UKTaxReturn                     uk.gov.hmrc.pillar2
 POST        /RESTAdapter/PLR/below-threshold-notification    uk.gov.hmrc.pillar2externalteststub.controllers.BTNController.submitBTN
 
 GET         /RESTAdapter/plr/obligations-and-submissions     uk.gov.hmrc.pillar2externalteststub.controllers.ObligationsAndSubmissionsController.getObligationsAndSubmissions(fromDate: String, toDate: String)
+POST        /RESTAdapter/PLR/overseas-return-notification    uk.gov.hmrc.pillar2externalteststub.controllers.ORNController.submitORN
+PUT         /RESTAdapter/PLR/overseas-return-notification    uk.gov.hmrc.pillar2externalteststub.controllers.ORNController.amendORN
+GET         /RESTAdapter/PLR/overseas-return-notification    uk.gov.hmrc.pillar2externalteststub.controllers.ORNController.getORN(accountingPeriodFrom: String, accountingPeriodTo: String)
 
 # organisation routes
 POST        /pillar2/test/organisation/:pillar2Id                uk.gov.hmrc.pillar2externalteststub.controllers.OrganisationController.create(pillar2Id: String)

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/ORNISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/ORNISpec.scala
@@ -1,0 +1,321 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub
+
+import org.mockito.ArgumentMatchers.{eq => eqTo}
+import org.mockito.Mockito.when
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.Json
+import play.api.{Application, inject}
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+import uk.gov.hmrc.pillar2externalteststub.helpers.{ORNDataFixture, TestOrgDataFixture}
+import uk.gov.hmrc.pillar2externalteststub.models.orn.ORNRequest
+import uk.gov.hmrc.pillar2externalteststub.models.orn.mongo.ORNSubmission
+import uk.gov.hmrc.pillar2externalteststub.repositories.ORNSubmissionRepository
+import uk.gov.hmrc.pillar2externalteststub.services.OrganisationService
+import uk.gov.hmrc.pillar2externalteststub.models.error.OrganisationNotFound
+import scala.concurrent.{ExecutionContext, Future}
+
+class ORNISpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaFutures
+    with IntegrationPatience
+    with GuiceOneServerPerSuite
+    with DefaultPlayMongoRepositorySupport[ORNSubmission]
+    with BeforeAndAfterEach
+    with ORNDataFixture
+    with TestOrgDataFixture {
+
+  override protected val databaseName: String = "test-orn-integration"
+
+  private val httpClient = app.injector.instanceOf[HttpClientV2]
+  private val baseUrl    = s"http://localhost:$port"
+  override protected val repository: ORNSubmissionRepository = app.injector.instanceOf[ORNSubmissionRepository]
+  implicit val ec:                   ExecutionContext        = app.injector.instanceOf[ExecutionContext]
+  implicit val hc:                   HeaderCarrier           = HeaderCarrier()
+
+  override def fakeApplication(): Application =
+    GuiceApplicationBuilder()
+      .configure(
+        "mongodb.uri"             -> s"mongodb://localhost:27017/$databaseName",
+        "metrics.enabled"         -> false,
+        "defaultDataExpireInDays" -> 28
+      )
+      .overrides(inject.bind[OrganisationService].toInstance(mockOrgService))
+      .build()
+
+  private def submitORN(pillar2Id: String, request: ORNRequest): HttpResponse = {
+    val headers = Seq(
+      "Content-Type"  -> "application/json",
+      "Authorization" -> "Bearer token",
+      "X-Pillar2-Id"  -> pillar2Id
+    )
+
+    httpClient
+      .post(url"$baseUrl/RESTAdapter/PLR/overseas-return-notification")
+      .transform(_.withHttpHeaders(headers: _*))
+      .withBody(Json.toJson(request))
+      .execute[HttpResponse]
+      .futureValue
+  }
+
+  private def amendORN(pillar2Id: String, request: ORNRequest): HttpResponse = {
+    val headers = Seq(
+      "Content-Type"  -> "application/json",
+      "Authorization" -> "Bearer token",
+      "X-Pillar2-Id"  -> pillar2Id
+    )
+
+    httpClient
+      .put(url"$baseUrl/RESTAdapter/PLR/overseas-return-notification")
+      .transform(_.withHttpHeaders(headers: _*))
+      .withBody(Json.toJson(request))
+      .execute[HttpResponse]
+      .futureValue
+  }
+
+  private def getORN(pillar2Id: String, accountingPeriodFrom: String, accountingPeriodTo: String): HttpResponse = {
+    val headers = Seq(
+      "Content-Type"  -> "application/json",
+      "Authorization" -> "Bearer token",
+      "X-Pillar2-Id"  -> pillar2Id
+    )
+
+    httpClient
+      .get(url"$baseUrl/RESTAdapter/PLR/overseas-return-notification?accountingPeriodFrom=$accountingPeriodFrom&accountingPeriodTo=$accountingPeriodTo")
+      .transform(_.withHttpHeaders(headers: _*))
+      .execute[HttpResponse]
+      .futureValue
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    prepareDatabase()
+  }
+
+  override protected def prepareDatabase(): Unit = {
+    repository.collection.drop().toFuture().futureValue
+    repository.collection.createIndexes(repository.indexes).toFuture().futureValue
+    ()
+  }
+
+  "ORN submission endpoint" should {
+    "successfully save and retrieve ORN submissions" in {
+      when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
+
+      val response = submitORN(validPlrId, validORNRequest)
+      response.status shouldBe 201
+
+      val submissions = repository.findByPillar2Id(validPlrId).futureValue
+      submissions.size shouldBe 1
+      val submission = submissions.head
+      submission.pillar2Id shouldBe validPlrId
+      submission.accountingPeriodFrom shouldBe validORNRequest.accountingPeriodFrom
+      submission.accountingPeriodTo shouldBe validORNRequest.accountingPeriodTo
+    }
+
+    "return 422 with tax obligation already fulfilled when submitting duplicate ORN" in {
+      when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
+
+      // First submission
+      val firstResponse = submitORN(validPlrId, validORNRequest)
+      firstResponse.status shouldBe 201
+
+      // Second submission with same accounting period
+      val secondResponse = submitORN(validPlrId, validORNRequest)
+      secondResponse.status shouldBe 422
+      val json = Json.parse(secondResponse.body)
+      (json \ "errors" \ "code").as[String] shouldBe "044"
+      (json \ "errors" \ "text").as[String] shouldBe "Tax obligation already fulfilled"
+    }
+
+    "allow submission for different accounting periods" in {
+      when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
+
+      // First submission
+      val firstResponse = submitORN(validPlrId, validORNRequest)
+      firstResponse.status shouldBe 201
+
+      // Second submission with different accounting period
+      val differentPeriodRequest = validORNRequest.copy(
+        accountingPeriodFrom = validORNRequest.accountingPeriodFrom.plusYears(1),
+        accountingPeriodTo = validORNRequest.accountingPeriodTo.plusYears(1)
+      )
+      val secondResponse = submitORN(validPlrId, differentPeriodRequest)
+      secondResponse.status shouldBe 201
+
+      val submissions = repository.findByPillar2Id(validPlrId).futureValue
+      submissions.size shouldBe 2
+    }
+
+    "successfully amend an existing ORN submission" in {
+      when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
+
+      val submitResponse = submitORN(validPlrId, validORNRequest)
+      submitResponse.status shouldBe 201
+
+      val amendedRequest = validORNRequest.copy(
+        reportingEntityName = "Updated Newco PLC"
+      )
+      val amendResponse = amendORN(validPlrId, amendedRequest)
+      amendResponse.status shouldBe 200
+
+      val submissions = repository.findByPillar2Id(validPlrId).futureValue
+      submissions.size shouldBe 2
+      submissions.last.reportingEntityName shouldBe "Updated Newco PLC"
+    }
+
+    "return 422 when attempting to amend non-existent ORN" in {
+      when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
+
+      val amendResponse = amendORN(validPlrId, validORNRequest)
+      amendResponse.status shouldBe 422
+      val json = Json.parse(amendResponse.body)
+      (json \ "errors" \ "code").as[String] shouldBe "003"
+      (json \ "errors" \ "text").as[String] shouldBe "Request could not be processed"
+
+      val submissions = repository.findByPillar2Id(validPlrId).futureValue
+      submissions shouldBe empty
+    }
+
+    "handle invalid requests appropriately" in {
+      val headers = Seq(
+        "Content-Type"  -> "application/json",
+        "Authorization" -> "Bearer token"
+      )
+
+      val responseWithoutId = httpClient
+        .post(url"$baseUrl/RESTAdapter/PLR/overseas-return-notification")
+        .transform(_.withHttpHeaders(headers: _*))
+        .withBody(Json.toJson(validORNRequest))
+        .execute[HttpResponse]
+        .futureValue
+
+      responseWithoutId.status shouldBe 422
+      val json = Json.parse(responseWithoutId.body)
+      (json \ "errors" \ "code").as[String] shouldBe "002"
+
+      repository.findByPillar2Id(validPlrId).futureValue shouldBe empty
+    }
+
+    "handle server error cases correctly" in {
+      val response = submitORN(serverErrorPlrId, validORNRequest)
+
+      response.status shouldBe 500
+      val json = Json.parse(response.body)
+      (json \ "errors" \ "code").as[String] shouldBe "500"
+
+      repository.findByPillar2Id(serverErrorPlrId).futureValue shouldBe empty
+    }
+
+    "handle non-existent organisation" in {
+      when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.failed(OrganisationNotFound(validPlrId)))
+
+      val response = submitORN(validPlrId, validORNRequest)
+      response.status shouldBe 422
+      val json = Json.parse(response.body)
+      (json \ "errors" \ "code").as[String] shouldBe "007"
+    }
+  }
+
+  "GET ORN endpoint" should {
+    "successfully retrieve an existing ORN submission" in {
+      when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
+
+      // First create a submission
+      val submitResponse = submitORN(validPlrId, validORNRequest)
+      submitResponse.status shouldBe 201
+
+      // Then retrieve it
+      val getResponse = getORN(validPlrId, validORNRequest.accountingPeriodFrom.toString, validORNRequest.accountingPeriodTo.toString)
+      getResponse.status shouldBe 200
+      
+      val submission = Json.parse(getResponse.body)
+      (submission \ "success" \ "accountingPeriodFrom").as[String] shouldBe validORNRequest.accountingPeriodFrom.toString
+      (submission \ "success" \ "accountingPeriodTo").as[String] shouldBe validORNRequest.accountingPeriodTo.toString
+      (submission \ "success" \ "filedDateGIR").as[String] shouldBe validORNRequest.filedDateGIR.toString
+      (submission \ "success" \ "countryGIR").as[String] shouldBe validORNRequest.countryGIR
+      (submission \ "success" \ "reportingEntityName").as[String] shouldBe validORNRequest.reportingEntityName
+      (submission \ "success" \ "TIN").as[String] shouldBe validORNRequest.TIN
+      (submission \ "success" \ "issuingCountryTIN").as[String] shouldBe validORNRequest.issuingCountryTIN
+      (submission \ "success" \ "processingDate").as[String] should not be empty
+    }
+
+    "return 422 when no submission exists for the given period" in {
+      when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
+
+      val getResponse = getORN(validPlrId, "2025-01-01", "2025-12-31")
+      getResponse.status shouldBe 422
+      val json = Json.parse(getResponse.body)
+      (json \ "errors" \ "code").as[String] shouldBe "003"
+      (json \ "errors" \ "text").as[String] shouldBe "Request could not be processed"
+    }
+
+    "return 422 when dates are invalid" in {
+      when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
+
+      val getResponse = getORN(validPlrId, "invalid-date", "2025-12-31")
+      getResponse.status shouldBe 422
+      val json = Json.parse(getResponse.body)
+      (json \ "errors" \ "code").as[String] shouldBe "003"
+      (json \ "errors" \ "text").as[String] shouldBe "Request could not be processed"
+    }
+
+    "return 422 when Pillar2 ID is missing" in {
+      val headers = Seq(
+        "Content-Type"  -> "application/json",
+        "Authorization" -> "Bearer token"
+      )
+
+      val getResponse = httpClient
+        .get(url"$baseUrl/RESTAdapter/PLR/overseas-return-notification?accountingPeriodFrom=2024-01-01&accountingPeriodTo=2024-12-31")
+        .transform(_.withHttpHeaders(headers: _*))
+        .execute[HttpResponse]
+        .futureValue
+
+      getResponse.status shouldBe 422
+      val json = Json.parse(getResponse.body)
+      (json \ "errors" \ "code").as[String] shouldBe "002"
+    }
+
+    "return 422 when organisation does not exist" in {
+      when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.failed(OrganisationNotFound(validPlrId)))
+
+      val getResponse = getORN(validPlrId, "2024-01-01", "2024-12-31")
+      getResponse.status shouldBe 422
+      val json = Json.parse(getResponse.body)
+      (json \ "errors" \ "code").as[String] shouldBe "003"
+    }
+
+    "return 500 for server error PLR ID" in {
+      val getResponse = getORN(serverErrorPlrId, "2024-01-01", "2024-12-31")
+      getResponse.status shouldBe 500
+      val json = Json.parse(getResponse.body)
+      (json \ "errors" \ "code").as[String] shouldBe "500"
+    }
+  }
+}
+

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/ORNISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/ORNISpec.scala
@@ -274,14 +274,14 @@ class ORNISpec
       (json \ "errors" \ "text").as[String] shouldBe "Request could not be processed"
     }
 
-    "return 422 when dates are invalid" in {
+    "return 400 when dates are invalid" in {
       when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
 
       val getResponse = getORN(validPlrId, "invalid-date", "2025-12-31")
-      getResponse.status shouldBe 422
+      getResponse.status shouldBe 400
       val json = Json.parse(getResponse.body)
-      (json \ "errors" \ "code").as[String] shouldBe "003"
-      (json \ "errors" \ "text").as[String] shouldBe "Request could not be processed"
+      (json \ "errors" \ "code").as[String] shouldBe "400"
+      (json \ "errors" \ "text").as[String] shouldBe "Bad request"
     }
 
     "return 422 when Pillar2 ID is missing" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/ORNControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/ORNControllerSpec.scala
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.controllers
+
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.Mockito.when
+import org.scalatest.compatible.Assertion
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.Json
+import play.api.mvc.Result
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import play.api.{Application, inject}
+import uk.gov.hmrc.pillar2externalteststub.helpers.{ORNDataFixture, TestOrgDataFixture}
+import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError._
+import uk.gov.hmrc.pillar2externalteststub.models.error.OrganisationNotFound
+import uk.gov.hmrc.pillar2externalteststub.models.orn.ORNRequest
+import uk.gov.hmrc.pillar2externalteststub.repositories.ORNSubmissionRepository
+import uk.gov.hmrc.pillar2externalteststub.services.{ORNService, OrganisationService}
+
+import java.time.LocalDate
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class ORNControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSuite with MockitoSugar with ORNDataFixture with TestOrgDataFixture {
+
+  implicit class AwaitFuture(fut: Future[Result]) {
+    def shouldFailWith(expected: Throwable): Assertion = {
+      val err = Await.result(fut.failed, 5.seconds)
+      err shouldBe expected
+    }
+  }
+
+  private val mockRepository = mock[ORNSubmissionRepository]
+  private val mockORNService = mock[ORNService]
+
+  override def fakeApplication(): Application =
+    GuiceApplicationBuilder()
+      .overrides(inject.bind[OrganisationService].toInstance(mockOrgService))
+      .overrides(inject.bind[ORNSubmissionRepository].toInstance(mockRepository))
+      .overrides(inject.bind[ORNService].toInstance(mockORNService))
+      .build()
+
+  "Overseas Return Notification" - {
+    "when submitting an ORN" - {
+      "should return CREATED with success response for a valid submission" in {
+        when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
+        when(mockORNService.submitORN(eqTo(validPlrId), any[ORNRequest])).thenReturn(Future.successful(true))
+
+        val result = route(app, createRequestWithBody(validPlrId, validORNRequest)).get
+        status(result) shouldBe CREATED
+        val json = contentAsJson(result)
+        (json \ "success" \ "processingDate").asOpt[String].isDefined   shouldBe true
+        (json \ "success" \ "formBundleNumber").asOpt[String].isDefined shouldBe true
+      }
+
+      "should return Pillar2IdMissing when X-Pillar2-Id header is missing" in {
+        val request = FakeRequest(POST, "/RESTAdapter/PLR/overseas-return-notification")
+          .withHeaders("Content-Type" -> "application/json", authHeader)
+          .withBody(validRequestBody)
+
+        val result = route(app, request).get
+        result shouldFailWith Pillar2IdMissing
+      }
+
+      "should return Pillar2IdMissing when Pillar2 ID format is invalid" in {
+        val invalidPlrId = "invalid@id"
+        val result       = route(app, createRequestWithBody(invalidPlrId, validORNRequest)).get
+        result shouldFailWith Pillar2IdMissing
+      }
+
+      "should return NoActiveSubscription when organisation not found" in {
+        when(mockOrgService.getOrganisation(any[String]))
+          .thenReturn(Future.failed(OrganisationNotFound("Organisation not found")))
+
+        val result = route(app, createRequestWithBody(validPlrId, validORNRequest)).get
+        result shouldFailWith NoActiveSubscription
+      }
+
+      "should return ETMPBadRequest when request body is invalid JSON" in {
+        val result = route(app, createSubmitRequest(validPlrId, Json.obj("invalid" -> "request"))).get
+        result shouldFailWith ETMPBadRequest
+      }
+
+      "should return ETMPInternalServerError when specific Pillar2 ID indicates server error" in {
+        val serverErrorPlrId = "XEPLR5000000000"
+        val result           = route(app, createRequestWithBody(serverErrorPlrId, validORNRequest)).get
+        result shouldFailWith ETMPInternalServerError
+      }
+    }
+
+    "when amending an ORN" - {
+      "should return OK with success response for a valid amendment" in {
+        when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
+        when(mockORNService.amendORN(eqTo(validPlrId), any[ORNRequest])).thenReturn(Future.successful(true))
+
+        val result = route(app, createRequestWithBody(validPlrId, validORNRequest, isAmend = true)).get
+        status(result) shouldBe OK
+        val json = contentAsJson(result)
+        (json \ "success" \ "processingDate").asOpt[String].isDefined   shouldBe true
+        (json \ "success" \ "formBundleNumber").asOpt[String].isDefined shouldBe true
+      }
+
+      "should return UNPROCESSABLE_ENTITY when organisation not found during amendment" in {
+        when(mockOrgService.getOrganisation(any[String]))
+          .thenReturn(Future.failed(OrganisationNotFound("Organisation not found")))
+
+        val result = route(app, createRequestWithBody(validPlrId, validORNRequest, isAmend = true)).get
+        result shouldFailWith NoActiveSubscription
+      }
+
+      "should return BAD_REQUEST when amendment request body is invalid JSON" in {
+        val result = route(app, createAmendRequest(validPlrId, Json.obj("invalid" -> "request"))).get
+        result shouldFailWith ETMPBadRequest
+      }
+    }
+
+    "when retrieving an ORN" - {
+      "should return OK with submission details for a valid request" in {
+        val fromDate = "2024-01-01"
+        val toDate   = "2024-12-31"
+
+        when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
+        when(mockORNService.getORN(eqTo(validPlrId), any[LocalDate], any[LocalDate]))
+          .thenReturn(Future.successful(Some(ornMongoSubmission)))
+
+        val request = FakeRequest(GET, s"/RESTAdapter/PLR/overseas-return-notification?accountingPeriodFrom=$fromDate&accountingPeriodTo=$toDate")
+          .withHeaders("Content-Type" -> "application/json", authHeader, "X-Pillar2-Id" -> validPlrId)
+
+        val result = route(app, request).get
+        status(result) shouldBe OK
+        val json = contentAsJson(result)
+        (json \ "success" \ "processingDate").asOpt[String].isDefined shouldBe true
+        (json \ "success" \ "accountingPeriodFrom").as[String]        shouldBe fromDate
+        (json \ "success" \ "accountingPeriodTo").as[String]          shouldBe toDate
+        (json \ "success" \ "countryGIR").as[String]                  shouldBe "US"
+      }
+
+      "should return UNPROCESSABLE_ENTITY when no submission is found" in {
+        val fromDate = "2024-01-01"
+        val toDate   = "2024-12-31"
+
+        when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
+        when(mockORNService.getORN(eqTo(validPlrId), any[LocalDate], any[LocalDate]))
+          .thenReturn(Future.successful(None))
+
+        val request = FakeRequest(GET, s"/RESTAdapter/PLR/overseas-return-notification?accountingPeriodFrom=$fromDate&accountingPeriodTo=$toDate")
+          .withHeaders("Content-Type" -> "application/json", authHeader, "X-Pillar2-Id" -> validPlrId)
+
+        val result = route(app, request).get
+        result shouldFailWith RequestCouldNotBeProcessed
+      }
+
+      "should return UNPROCESSABLE_ENTITY when date format is invalid" in {
+        val fromDate = "invalid-date"
+        val toDate   = "2024-12-31"
+
+        val request = FakeRequest(GET, s"/RESTAdapter/PLR/overseas-return-notification?accountingPeriodFrom=$fromDate&accountingPeriodTo=$toDate")
+          .withHeaders("Content-Type" -> "application/json", authHeader, "X-Pillar2-Id" -> validPlrId)
+
+        val result = route(app, request).get
+        result shouldFailWith RequestCouldNotBeProcessed
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/ORNControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/ORNControllerSpec.scala
@@ -155,7 +155,7 @@ class ORNControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSui
         (json \ "success" \ "countryGIR").as[String]                  shouldBe "US"
       }
 
-      "should return UNPROCESSABLE_ENTITY when no submission is found" in {
+      "should return RequestCouldNotBeProcessed when no submission is found" in {
         val fromDate = "2024-01-01"
         val toDate   = "2024-12-31"
 
@@ -170,7 +170,7 @@ class ORNControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSui
         result shouldFailWith RequestCouldNotBeProcessed
       }
 
-      "should return UNPROCESSABLE_ENTITY when date format is invalid" in {
+      "should return ETMPBadRequest when date format is invalid" in {
         val fromDate = "invalid-date"
         val toDate   = "2024-12-31"
 
@@ -178,7 +178,7 @@ class ORNControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSui
           .withHeaders("Content-Type" -> "application/json", authHeader, "X-Pillar2-Id" -> validPlrId)
 
         val result = route(app, request).get
-        result shouldFailWith RequestCouldNotBeProcessed
+        result shouldFailWith ETMPBadRequest
       }
     }
   }

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/ORNDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/ORNDataFixture.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.helpers
+
+import org.bson.types.ObjectId
+import play.api.http.HeaderNames
+import play.api.libs.json.{JsValue, Json}
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{POST, PUT}
+import uk.gov.hmrc.pillar2externalteststub.models.orn.ORNRequest
+import uk.gov.hmrc.pillar2externalteststub.models.orn.mongo.ORNSubmission
+
+import java.time.{Instant, LocalDate}
+
+trait ORNDataFixture extends Pillar2DataFixture {
+
+  val validORNRequest: ORNRequest = ORNRequest(
+    accountingPeriodFrom = accountingPeriod.startDate,
+    accountingPeriodTo = accountingPeriod.endDate,
+    filedDateGIR = LocalDate.of(2025, 1, 10),
+    countryGIR = "US",
+    reportingEntityName = "Newco PLC",
+    TIN = "US12345678",
+    issuingCountryTIN = "US"
+  )
+
+  val validRequestBody: JsValue = Json.toJson(validORNRequest)
+
+  val ornMongoSubmission: ORNSubmission = ORNSubmission(
+    _id = new ObjectId(),
+    pillar2Id = validPlrId,
+    accountingPeriodFrom = validORNRequest.accountingPeriodFrom,
+    accountingPeriodTo = validORNRequest.accountingPeriodTo,
+    filedDateGIR = validORNRequest.filedDateGIR,
+    countryGIR = validORNRequest.countryGIR,
+    reportingEntityName = validORNRequest.reportingEntityName,
+    TIN = validORNRequest.TIN,
+    issuingCountryTIN = validORNRequest.issuingCountryTIN,
+    submittedAt = Instant.now()
+  )
+
+  def createSubmitRequest(plrId: String, body: JsValue): FakeRequest[JsValue] =
+    FakeRequest(POST, "/RESTAdapter/PLR/overseas-return-notification")
+      .withHeaders(HeaderNames.CONTENT_TYPE -> "application/json", authHeader, "X-Pillar2-Id" -> plrId)
+      .withBody(body)
+
+  def createAmendRequest(plrId: String, body: JsValue): FakeRequest[JsValue] =
+    FakeRequest(PUT, "/RESTAdapter/PLR/overseas-return-notification")
+      .withHeaders(HeaderNames.CONTENT_TYPE -> "application/json", authHeader, "X-Pillar2-Id" -> plrId)
+      .withBody(body)
+
+  def createRequestWithBody(plrId: String, request: ORNRequest, isAmend: Boolean = false): FakeRequest[JsValue] =
+    if (isAmend) createAmendRequest(plrId, Json.toJson(request))
+    else createSubmitRequest(plrId, Json.toJson(request))
+}

--- a/test/uk/gov/hmrc/pillar2externalteststub/repositories/ORNSubmissionRepositorySpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/repositories/ORNSubmissionRepositorySpec.scala
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.repositories
+
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.Configuration
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+import uk.gov.hmrc.pillar2externalteststub.config.AppConfig
+import uk.gov.hmrc.pillar2externalteststub.helpers.ORNDataFixture
+import uk.gov.hmrc.pillar2externalteststub.models.orn.ORNRequest
+import uk.gov.hmrc.pillar2externalteststub.models.orn.mongo.ORNSubmission
+
+import java.time.LocalDate
+import scala.concurrent.ExecutionContext
+
+class ORNSubmissionRepositorySpec
+    extends AnyWordSpec
+    with Matchers
+    with DefaultPlayMongoRepositorySupport[ORNSubmission]
+    with ScalaFutures
+    with IntegrationPatience
+    with ORNDataFixture {
+
+  override protected val databaseName: String = "orn-submission-repository"
+
+  val config = new AppConfig(
+    Configuration.from(
+      Map(
+        "appName"                 -> "pillar2-external-test-stub",
+        "defaultDataExpireInDays" -> 28
+      )
+    )
+  )
+
+  private val app = GuiceApplicationBuilder()
+    .configure(
+      "metrics.enabled"  -> false,
+      "encryptionToggle" -> "true"
+    )
+    .overrides(
+      bind[MongoComponent].toInstance(mongoComponent)
+    )
+    .build()
+
+  override protected val repository: ORNSubmissionRepository =
+    app.injector.instanceOf[ORNSubmissionRepository]
+
+  implicit val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
+
+  private val testPillar2Id = "XMPLR0000000000"
+  private val testRequest = ORNRequest(
+    accountingPeriodFrom = LocalDate.of(2024, 1, 1),
+    accountingPeriodTo = LocalDate.of(2024, 12, 31),
+    filedDateGIR = LocalDate.of(2025, 1, 10),
+    countryGIR = "US",
+    reportingEntityName = "Test Company",
+    TIN = "US12345678",
+    issuingCountryTIN = "US"
+  )
+
+  "insert" should {
+    "successfully insert a new ORN submission" in {
+      val result = repository.insert(testPillar2Id, testRequest).futureValue
+      result shouldBe true
+
+      val submissions = repository.findByPillar2Id(testPillar2Id).futureValue
+      submissions.size shouldBe 1
+      val submission = submissions.head
+      submission.pillar2Id            shouldBe testPillar2Id
+      submission.accountingPeriodFrom shouldBe testRequest.accountingPeriodFrom
+      submission.accountingPeriodTo   shouldBe testRequest.accountingPeriodTo
+      submission.filedDateGIR         shouldBe testRequest.filedDateGIR
+      submission.countryGIR           shouldBe testRequest.countryGIR
+      submission.reportingEntityName  shouldBe testRequest.reportingEntityName
+      submission.TIN                  shouldBe testRequest.TIN
+      submission.issuingCountryTIN    shouldBe testRequest.issuingCountryTIN
+    }
+
+    "allow submissions for same pillar2Id with different accounting periods" in {
+      repository.insert(testPillar2Id, testRequest).futureValue shouldBe true
+
+      val differentPeriodRequest = testRequest.copy(
+        accountingPeriodFrom = LocalDate.of(2025, 1, 1),
+        accountingPeriodTo = LocalDate.of(2025, 12, 31)
+      )
+      repository.insert(testPillar2Id, differentPeriodRequest).futureValue shouldBe true
+
+      val submissions = repository.findByPillar2Id(testPillar2Id).futureValue
+      submissions.size shouldBe 2
+    }
+
+    "allow submissions for different pillar2Ids with same accounting period" in {
+      repository.insert(testPillar2Id, testRequest).futureValue     shouldBe true
+      repository.insert("XMPLR0000000001", testRequest).futureValue shouldBe true
+
+      val submissions1 = repository.findByPillar2Id(testPillar2Id).futureValue
+      submissions1.size shouldBe 1
+
+      val submissions2 = repository.findByPillar2Id("XMPLR0000000001").futureValue
+      submissions2.size shouldBe 1
+    }
+  }
+
+  "findByPillar2Id" should {
+    "return empty sequence when no submissions exist" in {
+      repository.findByPillar2Id("NONEXISTENT").futureValue shouldBe empty
+    }
+
+    "return all submissions for a given pillar2Id" in {
+      val requests = List(
+        testRequest,
+        testRequest.copy(
+          accountingPeriodFrom = LocalDate.of(2025, 1, 1),
+          accountingPeriodTo = LocalDate.of(2025, 12, 31)
+        ),
+        testRequest.copy(
+          accountingPeriodFrom = LocalDate.of(2026, 1, 1),
+          accountingPeriodTo = LocalDate.of(2026, 12, 31)
+        )
+      )
+
+      requests.foreach(request => repository.insert(testPillar2Id, request).futureValue shouldBe true)
+
+      val submissions = repository.findByPillar2Id(testPillar2Id).futureValue
+      submissions.size                      shouldBe 3
+      submissions.map(_.accountingPeriodFrom) should contain theSameElementsAs requests.map(_.accountingPeriodFrom)
+    }
+  }
+
+  "findByPillar2IdAndAccountingPeriod" should {
+    "return None when no matching submission exists" in {
+      repository
+        .findByPillar2IdAndAccountingPeriod(
+          "NONEXISTENT",
+          LocalDate.of(2024, 1, 1),
+          LocalDate.of(2024, 12, 31)
+        )
+        .futureValue shouldBe None
+    }
+
+    "return the matching submission when one exists" in {
+      repository.insert(testPillar2Id, testRequest).futureValue shouldBe true
+
+      val submission = repository
+        .findByPillar2IdAndAccountingPeriod(
+          testPillar2Id,
+          testRequest.accountingPeriodFrom,
+          testRequest.accountingPeriodTo
+        )
+        .futureValue
+
+      submission.isDefined                shouldBe true
+      submission.get.pillar2Id            shouldBe testPillar2Id
+      submission.get.accountingPeriodFrom shouldBe testRequest.accountingPeriodFrom
+      submission.get.accountingPeriodTo   shouldBe testRequest.accountingPeriodTo
+    }
+
+    "return the most recent submission when multiple matching submissions exist" in {
+      // First insert the initial submission
+      repository.insert(testPillar2Id, testRequest).futureValue shouldBe true
+
+      // Then insert an updated submission with same Pillar2Id and accounting period
+      val updatedRequest = testRequest.copy(
+        reportingEntityName = "Updated Company Name"
+      )
+      repository.insert(testPillar2Id, updatedRequest).futureValue shouldBe true
+
+      val submission = repository
+        .findByPillar2IdAndAccountingPeriod(
+          testPillar2Id,
+          testRequest.accountingPeriodFrom,
+          testRequest.accountingPeriodTo
+        )
+        .futureValue
+
+      submission.isDefined               shouldBe true
+      submission.get.pillar2Id           shouldBe testPillar2Id
+      submission.get.reportingEntityName shouldBe "Updated Company Name"
+    }
+  }
+
+  "deleteByPillar2Id" should {
+    "successfully delete submissions for a given pillar2Id" in {
+      repository.insert(testPillar2Id, testRequest).futureValue
+      repository
+        .insert(
+          testPillar2Id,
+          testRequest.copy(
+            accountingPeriodFrom = LocalDate.of(2025, 1, 1),
+            accountingPeriodTo = LocalDate.of(2025, 12, 31)
+          )
+        )
+        .futureValue
+
+      repository.findByPillar2Id(testPillar2Id).futureValue.size shouldBe 2
+
+      repository.deleteByPillar2Id(testPillar2Id).futureValue shouldBe true
+      repository.findByPillar2Id(testPillar2Id).futureValue   shouldBe empty
+    }
+
+    "return true when attempting to delete non-existent pillar2Id" in {
+      val deleteResult = repository.deleteByPillar2Id("NONEXISTENT").futureValue
+      deleteResult shouldBe true
+    }
+  }
+}

--- a/test/uk/gov/hmrc/pillar2externalteststub/services/ORNServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/services/ORNServiceSpec.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.services
+
+import org.mockito.ArgumentMatchers.{any, anyString, eq => eqTo}
+import org.mockito.Mockito.{times, verify, when}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.pillar2externalteststub.helpers.ORNDataFixture
+import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.{RequestCouldNotBeProcessed, TaxObligationAlreadyFulfilled}
+import uk.gov.hmrc.pillar2externalteststub.models.orn.ORNRequest
+import uk.gov.hmrc.pillar2externalteststub.repositories.ORNSubmissionRepository
+
+import java.time.LocalDate
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+class ORNServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with ScalaFutures with ORNDataFixture {
+
+  private val mockRepository = mock[ORNSubmissionRepository]
+  private val service        = new ORNService(mockRepository)
+
+  "ORNService" should {
+    "submitORN" should {
+      "successfully submit a new ORN when no existing submission exists" in {
+        when(mockRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Seq.empty))
+        when(mockRepository.insert(anyString(), any[ORNRequest]())).thenReturn(Future.successful(true))
+
+        val result = service.submitORN(validPlrId, validORNRequest)
+
+        result.futureValue mustBe true
+        verify(mockRepository).insert(validPlrId, validORNRequest)
+      }
+
+      "fail with TaxObligationAlreadyFulfilled when a submission exists for the same accounting period" in {
+        when(mockRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Seq(ornMongoSubmission)))
+
+        val result = service.submitORN(validPlrId, validORNRequest)
+
+        whenReady(result.failed) { e =>
+          e mustBe TaxObligationAlreadyFulfilled
+        }
+      }
+    }
+
+    "amendORN" should {
+      "successfully amend an existing ORN when a submission exists" in {
+        val amendedRequest = validORNRequest.copy(reportingEntityName = "Updated Name")
+
+        when(mockRepository.findByPillar2Id(eqTo(validPlrId))).thenReturn(Future.successful(Seq(ornMongoSubmission)))
+        when(mockRepository.insert(eqTo(validPlrId), eqTo(amendedRequest))).thenReturn(Future.successful(true))
+
+        val result = service.amendORN(validPlrId, amendedRequest)
+
+        result.futureValue mustBe true
+        verify(mockRepository, times(1)).insert(validPlrId, amendedRequest)
+      }
+
+      "fail with RequestCouldNotBeProcessed when no existing submission exists" in {
+        when(mockRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Seq.empty))
+
+        val result = service.amendORN(validPlrId, validORNRequest)
+
+        whenReady(result.failed) { e =>
+          e mustBe RequestCouldNotBeProcessed
+        }
+      }
+    }
+
+    "getORN" should {
+      "return submission when it exists for the given period" in {
+        val submission = ornMongoSubmission
+        when(mockRepository.findByPillar2IdAndAccountingPeriod(anyString(), any[LocalDate], any[LocalDate]))
+          .thenReturn(Future.successful(Some(submission)))
+
+        val result = service.getORN(validPlrId, submission.accountingPeriodFrom, submission.accountingPeriodTo)
+        result.futureValue mustBe Some(submission)
+      }
+
+      "return None when no submission exists for the period" in {
+        when(mockRepository.findByPillar2IdAndAccountingPeriod(anyString(), any[LocalDate], any[LocalDate]))
+          .thenReturn(Future.successful(None))
+
+        val result = service.getORN(validPlrId, LocalDate.now(), LocalDate.now())
+        result.futureValue mustBe None
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR implements the three required endpoints for Overseas Return Notification (ORN) to our external test stub:

- **POST /RESTAdapter/PLR/overseas-return-notification** - Submit a new ORN
- **PUT /RESTAdapter/PLR/overseas-return-notification** - Amend an existing ORN
- **GET /RESTAdapter/PLR/overseas-return-notification** - Retrieve the latest ORN for a specific accounting period

## Implementation Details

- Created new models:
  - `ORNRequest` - For handling submission and amendment payloads
  - `ORNSubmission` - MongoDB model for storing submissions
  - `ORNGetResponse` - Response model for GET requests

- Implemented core components:
  - `ORNController` - Handles HTTP requests with proper error responses
  - `ORNService` - Business logic including duplicate checking
  - `ORNSubmissionRepository` - MongoDB data access with indexes

- Added validation and error handling for:
  - Missing/invalid Pillar2-ID headers
  - Duplicate submissions (returns 422 with code 044)
  - Non-existent submissions for GET requests
  - Invalid date formats
  - Authentication failures
  
- Updated the delete organisation endpoint to also remove all ORN submissions for the specific pillar2 id, ensuring proper cleanup along with other collections (BTN submissions, UKTR submissions, etc.)

- Added compound MongoDB index on `pillar2Id`, `accountingPeriodFrom`, and `accountingPeriodTo` for efficient queries

- Created comprehensive Bruno API test scripts:
  - Test valid submission, amendment, and retrieval flows
  - Test all error scenarios including 400, 401/403, 422, and 500 responses
  - Properly sequence tests for testing duplicate submission errors

Note: Additional validation for future dates and other scenarios will be added as part of PIL-1630.
