### PR TITLE
PIL-1816 - Proposal

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsController.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsController.scala
@@ -71,52 +71,88 @@ class ObligationsAndSubmissionsController @Inject() (
   }
 
   private def generateHistory(testOrg: TestOrganisationWithId, oasSubmissions: Seq[ObligationsAndSubmissionsMongoSubmission]): Result = {
-    val dueDate  = testOrg.organisation.accountingPeriod.endDate.plusMonths(15)
-    val canAmend = if (LocalDate.now().isAfter(dueDate)) false else true
-    val submissions = oasSubmissions.map(submission =>
-      Submission(
-        submissionType = submission.submissionType,
-        receivedDate = submission.submittedAt.atZone(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS),
-        country = if (submission.submissionType == ORN) Some("FR") else None
+    // Group submissions by accounting period
+    val submissionsByPeriod = oasSubmissions.groupBy(_.accountingPeriod)
+
+    // If no submissions, return the organisation's default accounting period
+    val accountingPeriodDetails = if (submissionsByPeriod.isEmpty) {
+      Seq(
+        createAccountingPeriodDetails(
+          testOrg.organisation.accountingPeriod.startDate,
+          testOrg.organisation.accountingPeriod.endDate,
+          Seq.empty,
+          testOrg.organisation.orgDetails.domesticOnly
+        )
       )
-    )
-    val p2TaxReturnSubmissions = submissions.filter(s => s.submissionType == UKTR || s.submissionType == BTN)
-    val girSubmissions         = submissions.filter(s => s.submissionType == BTN || s.submissionType == GIR || s.submissionType == ORN)
+    } else {
+      // Create AccountingPeriodDetails for each group
+      submissionsByPeriod.map { case (accountingPeriod, submissions) =>
+        createAccountingPeriodDetails(
+          accountingPeriod.startDate,
+          accountingPeriod.endDate,
+          submissions.map(toSubmission),
+          testOrg.organisation.orgDetails.domesticOnly
+        )
+      }.toSeq
+    }
 
     Ok(
       Json.toJson(
         ObligationsAndSubmissionsSuccessResponse(
           ObligationsAndSubmissionsSuccess(
             processingDate = ZonedDateTime.parse(nowZonedDateTime),
-            accountingPeriodDetails = Seq(
-              AccountingPeriodDetails(
-                startDate = testOrg.organisation.accountingPeriod.startDate,
-                endDate = testOrg.organisation.accountingPeriod.endDate,
-                dueDate = dueDate,
-                underEnquiry = false,
-                obligations = {
-                  val domesticObligation = Seq(
-                    Obligation(
-                      obligationType = Pillar2TaxReturn,
-                      status = if (p2TaxReturnSubmissions.isEmpty) Open else Fulfilled,
-                      canAmend = canAmend,
-                      submissions = p2TaxReturnSubmissions
-                    )
-                  )
-                  if (!testOrg.organisation.orgDetails.domesticOnly) {
-                    domesticObligation :+ Obligation(
-                      obligationType = GlobeInformationReturn,
-                      status = if (girSubmissions.isEmpty) Open else Fulfilled,
-                      canAmend = canAmend,
-                      submissions = girSubmissions
-                    )
-                  } else domesticObligation
-                }
-              )
-            )
+            accountingPeriodDetails = accountingPeriodDetails
           )
         )
       )
+    )
+  }
+
+  private def toSubmission(submission: ObligationsAndSubmissionsMongoSubmission): Submission =
+    Submission(
+      submissionType = submission.submissionType,
+      receivedDate = submission.submittedAt.atZone(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS),
+      country = if (submission.submissionType == ORN) Some("FR") else None
+    )
+
+  private def createAccountingPeriodDetails(
+    startDate:      LocalDate,
+    endDate:        LocalDate,
+    submissions:    Seq[Submission],
+    isDomesticOnly: Boolean
+  ): AccountingPeriodDetails = {
+    val dueDate  = endDate.plusMonths(15)
+    val canAmend = !LocalDate.now().isAfter(dueDate)
+
+    val p2TaxReturnSubmissions = submissions.filter(s => s.submissionType == UKTR || s.submissionType == BTN)
+    val girSubmissions         = submissions.filter(s => s.submissionType == BTN || s.submissionType == GIR || s.submissionType == ORN)
+
+    val domesticObligation = Seq(
+      Obligation(
+        obligationType = Pillar2TaxReturn,
+        status = if (p2TaxReturnSubmissions.isEmpty) Open else Fulfilled,
+        canAmend = canAmend,
+        submissions = p2TaxReturnSubmissions
+      )
+    )
+
+    val obligations = if (!isDomesticOnly) {
+      domesticObligation :+ Obligation(
+        obligationType = GlobeInformationReturn,
+        status = if (girSubmissions.isEmpty) Open else Fulfilled,
+        canAmend = canAmend,
+        submissions = girSubmissions
+      )
+    } else {
+      domesticObligation
+    }
+
+    AccountingPeriodDetails(
+      startDate = startDate,
+      endDate = endDate,
+      dueDate = dueDate,
+      underEnquiry = false,
+      obligations = obligations
     )
   }
 }

--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsController.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsController.scala
@@ -56,13 +56,7 @@ class ObligationsAndSubmissionsController @Inject() (
         from <- Future.fromTry(Try(LocalDate.parse(fromDate)))
         to   <- Future.fromTry(Try(LocalDate.parse(toDate)))
         _ = if (from.isAfter(to)) throw RequestCouldNotBeProcessed
-        testOrg <- organisationService.getOrganisation(pillar2Id)
-        _ = {
-          val orgStartDate = testOrg.organisation.accountingPeriod.startDate
-          val orgEndDate   = testOrg.organisation.accountingPeriod.endDate
-
-          if (from.isAfter(orgEndDate) || to.isBefore(orgStartDate)) throw NoAssociatedDataFound
-        }
+        testOrg        <- organisationService.getOrganisation(pillar2Id)
         oasSubmissions <- oasRepository.findByPillar2Id(pillar2Id, from, to)
       } yield generateHistory(testOrg, oasSubmissions))
         .recoverWith {

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/ObligationsAndSubmissionsISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/ObligationsAndSubmissionsISpec.scala
@@ -1,0 +1,347 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub
+
+import org.mongodb.scala.bson.ObjectId
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.{JsValue, Json}
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+import uk.gov.hmrc.pillar2externalteststub.helpers.{TestOrgDataFixture, UKTRDataFixture}
+import uk.gov.hmrc.pillar2externalteststub.models.obligationsAndSubmissions.SubmissionType
+import uk.gov.hmrc.pillar2externalteststub.models.obligationsAndSubmissions.SubmissionType._
+import uk.gov.hmrc.pillar2externalteststub.models.obligationsAndSubmissions.mongo.{AccountingPeriod, ObligationsAndSubmissionsMongoSubmission}
+import uk.gov.hmrc.pillar2externalteststub.repositories.{ObligationsAndSubmissionsRepository, OrganisationRepository}
+
+import java.time.Instant
+import scala.concurrent.ExecutionContext
+import java.time.LocalDate
+
+class ObligationsAndSubmissionsISpec
+    extends AnyWordSpec
+    with Matchers
+    with ScalaFutures
+    with IntegrationPatience
+    with GuiceOneServerPerSuite
+    with DefaultPlayMongoRepositorySupport[ObligationsAndSubmissionsMongoSubmission]
+    with BeforeAndAfterEach
+    with TestOrgDataFixture
+    with UKTRDataFixture {
+
+  override protected val databaseName: String = "test-obligations-and-submissions-integration"
+
+  private val httpClient = app.injector.instanceOf[HttpClientV2]
+  private val baseUrl    = s"http://localhost:$port"
+  override protected val repository: ObligationsAndSubmissionsRepository = app.injector.instanceOf[ObligationsAndSubmissionsRepository]
+  private val organisationRepository: OrganisationRepository             = app.injector.instanceOf[OrganisationRepository]
+  implicit val ec:                   ExecutionContext                    = app.injector.instanceOf[ExecutionContext]
+  implicit val hc:                   HeaderCarrier                       = HeaderCarrier()
+
+  override def fakeApplication(): Application =
+    GuiceApplicationBuilder()
+      .configure(
+        "mongodb.uri"             -> s"mongodb://localhost:27017/$databaseName",
+        "metrics.enabled"         -> false,
+        "defaultDataExpireInDays" -> 28
+      )
+      .build()
+
+  private def getObligationsAndSubmissions(
+    pillar2Id: String,
+    fromDate: String = accountingPeriod.startDate.toString,
+    toDate:   String = accountingPeriod.endDate.toString
+  ): HttpResponse = {
+    val headers = Seq(
+      "Content-Type"  -> "application/json",
+      authHeader,
+      "X-Pillar2-Id"  -> pillar2Id
+    )
+
+    httpClient
+      .get(url"$baseUrl/RESTAdapter/plr/obligations-and-submissions?fromDate=$fromDate&toDate=$toDate")
+      .transform(_.withHttpHeaders(headers: _*))
+      .execute[HttpResponse]
+      .futureValue
+  }
+
+  private def insertSubmission(
+    pillar2Id: String,
+    submissionType: SubmissionType,
+    accountingPeriod: AccountingPeriod
+  ): ObligationsAndSubmissionsMongoSubmission = {
+    val submission = ObligationsAndSubmissionsMongoSubmission(
+      _id = new ObjectId,
+      submissionId = new ObjectId,
+      pillar2Id = pillar2Id,
+      accountingPeriod = accountingPeriod,
+      submissionType = submissionType,
+      submittedAt = Instant.now()
+    )
+    repository.collection.insertOne(submission).toFuture().futureValue
+    submission
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    prepareDatabase()
+    organisationRepository.delete(validPlrId).futureValue
+    organisationRepository.delete(nonDomesticPlrId).futureValue
+    organisationRepository.insert(domesticOrganisation).futureValue
+    organisationRepository.insert(nonDomesticOrganisation).futureValue
+    ()
+  }
+
+  override protected def prepareDatabase(): Unit = {
+    repository.collection.drop().toFuture().futureValue
+    repository.collection.createIndexes(repository.indexes).toFuture()
+    ()
+  }
+
+  "ObligationsAndSubmissions endpoint" should {
+    "return correct response for domestic organisation with submissions" in {
+      // Insert a submission for the domestic organisation
+      insertSubmission(
+        domesticOrganisation.pillar2Id,
+        UKTR,
+        AccountingPeriod(accountingPeriod.startDate, accountingPeriod.endDate)
+      )
+
+      val response = getObligationsAndSubmissions(domesticOrganisation.pillar2Id)
+      response.status shouldBe 200
+
+      val json = Json.parse(response.body)
+      val accountingPeriodDetails = (json \ "success" \ "accountingPeriodDetails").as[Seq[JsValue]]
+      
+      accountingPeriodDetails.size shouldBe 1
+      
+      val obligations = (accountingPeriodDetails.head \ "obligations").as[Seq[JsValue]]
+      obligations.size shouldBe 1
+      
+      // Verify obligations for domestic organisation
+      (obligations.head \ "obligationType").as[String] shouldBe "Pillar2TaxReturn"
+      (obligations.head \ "status").as[String] shouldBe "Fulfilled"
+      
+      // Verify submissions
+      val submissions = (obligations.head \ "submissions").as[Seq[JsValue]]
+      submissions.size shouldBe 1
+      (submissions.head \ "submissionType").as[String] shouldBe "UKTR"
+    }
+
+    "return correct response for non-domestic organisation with submissions" in {
+      // Insert submissions for the non-domestic organisation
+      insertSubmission(
+        nonDomesticOrganisation.pillar2Id,
+        ORN,
+        AccountingPeriod(accountingPeriod.startDate, accountingPeriod.endDate)
+      )
+
+      val response = getObligationsAndSubmissions(nonDomesticOrganisation.pillar2Id)
+      response.status shouldBe 200
+
+      val json = Json.parse(response.body)
+      val accountingPeriodDetails = (json \ "success" \ "accountingPeriodDetails").as[Seq[JsValue]]
+      
+      accountingPeriodDetails.size shouldBe 1
+      
+      val obligations = (accountingPeriodDetails.head \ "obligations").as[Seq[JsValue]]
+      obligations.size shouldBe 2
+      
+      // Verify first obligation is Pillar2TaxReturn with Open status
+      (obligations.head \ "obligationType").as[String] shouldBe "Pillar2TaxReturn"
+      (obligations.head \ "status").as[String] shouldBe "Open"
+      
+      // Verify second obligation is GlobeInformationReturn with Fulfilled status
+      (obligations(1) \ "obligationType").as[String] shouldBe "GlobeInformationReturn"
+      (obligations(1) \ "status").as[String] shouldBe "Fulfilled"
+      
+      // Verify submissions in GIR obligation
+      val submissions = (obligations(1) \ "submissions").as[Seq[JsValue]]
+      submissions.size shouldBe 1
+      (submissions.head \ "submissionType").as[String] shouldBe "ORN"
+      (submissions.head \ "country").as[String] shouldBe "FR"
+    }
+
+    "group submissions by accounting period" in {
+      // Define two accounting periods
+      val period1 = AccountingPeriod(
+        startDate = LocalDate.of(2023, 1, 1),
+        endDate = LocalDate.of(2023, 12, 31)
+      )
+      
+      val period2 = AccountingPeriod(
+        startDate = LocalDate.of(2024, 1, 1),
+        endDate = LocalDate.of(2024, 12, 31)
+      )
+      
+      // Insert submissions for different accounting periods
+      insertSubmission(nonDomesticOrganisation.pillar2Id, UKTR, period1)
+      insertSubmission(nonDomesticOrganisation.pillar2Id, ORN, period1)
+      insertSubmission(nonDomesticOrganisation.pillar2Id, BTN, period2)
+      
+      val response = getObligationsAndSubmissions(
+        nonDomesticOrganisation.pillar2Id,
+        fromDate = "2023-01-01", 
+        toDate = "2024-12-31"
+      )
+      
+      response.status shouldBe 200
+      
+      val json = Json.parse(response.body)
+      val accountingPeriodDetails = (json \ "success" \ "accountingPeriodDetails").as[Seq[JsValue]]
+      
+      // Should have two accounting periods
+      accountingPeriodDetails.size shouldBe 2
+      
+      // Find period1 details
+      val period1Details = accountingPeriodDetails.find(period => 
+        (period \ "startDate").as[String] == "2023-01-01"
+      ).get
+      
+      // Find period2 details
+      val period2Details = accountingPeriodDetails.find(period => 
+        (period \ "startDate").as[String] == "2024-01-01"
+      ).get
+      
+      // Verify period1 has UKTR and ORN submissions
+      val period1Obligations = (period1Details \ "obligations").as[Seq[JsValue]]
+      val period1P2Status = (period1Obligations.head \ "status").as[String]
+      val period1GIRStatus = (period1Obligations(1) \ "status").as[String]
+      
+      period1P2Status shouldBe "Fulfilled"
+      period1GIRStatus shouldBe "Fulfilled"
+      
+      // Verify period2 has BTN submission
+      val period2Obligations = (period2Details \ "obligations").as[Seq[JsValue]]
+      val period2P2Status = (period2Obligations.head \ "status").as[String]
+      
+      period2P2Status shouldBe "Fulfilled"
+    }
+
+    "use organisation's default accounting period when no submissions exist" in {
+      val response = getObligationsAndSubmissions(domesticOrganisation.pillar2Id)
+      response.status shouldBe 200
+      
+      val json = Json.parse(response.body)
+      val accountingPeriodDetails = (json \ "success" \ "accountingPeriodDetails").as[Seq[JsValue]]
+      
+      // Should have only one accounting period
+      accountingPeriodDetails.size shouldBe 1
+      
+      // Period should match org's default period
+      (accountingPeriodDetails.head \ "startDate").as[String] shouldBe domesticOrganisation.organisation.accountingPeriod.startDate.toString
+      (accountingPeriodDetails.head \ "endDate").as[String] shouldBe domesticOrganisation.organisation.accountingPeriod.endDate.toString
+      
+      // Obligation should be Open
+      val obligations = (accountingPeriodDetails.head \ "obligations").as[Seq[JsValue]]
+      (obligations.head \ "status").as[String] shouldBe "Open"
+    }
+
+    "handle BTN submissions correctly" in {
+      // Insert BTN submission
+      insertSubmission(
+        nonDomesticOrganisation.pillar2Id,
+        BTN,
+        AccountingPeriod(accountingPeriod.startDate, accountingPeriod.endDate)
+      )
+      
+      val response = getObligationsAndSubmissions(nonDomesticOrganisation.pillar2Id)
+      response.status shouldBe 200
+      
+      val json = Json.parse(response.body)
+      val accountingPeriodDetails = (json \ "success" \ "accountingPeriodDetails").as[Seq[JsValue]]
+      val obligations = (accountingPeriodDetails.head \ "obligations").as[Seq[JsValue]]
+      
+      // BTN should fulfill both P2 and GIR obligations
+      (obligations.head \ "status").as[String] shouldBe "Fulfilled"
+      (obligations(1) \ "status").as[String] shouldBe "Fulfilled"
+      
+      // Verify BTN appears in both obligation types
+      val p2Submissions = (obligations.head \ "submissions").as[Seq[JsValue]]
+      val girSubmissions = (obligations(1) \ "submissions").as[Seq[JsValue]]
+      
+      (p2Submissions.head \ "submissionType").as[String] shouldBe "BTN"
+      (girSubmissions.head \ "submissionType").as[String] shouldBe "BTN"
+    }
+
+    "handle error cases correctly" in {
+      // Test organisation not found
+      val nonExistentPlrIdResponse = getObligationsAndSubmissions("NONEXISTENT")
+      println("nonExistentPlrIdResponse.body: " + nonExistentPlrIdResponse.body)
+      val nonExistentPlrIdJson = Json.parse(nonExistentPlrIdResponse.body)
+      (nonExistentPlrIdJson \ "errors" \ "text").as[String] shouldBe "No associated data found"
+      nonExistentPlrIdResponse.status shouldBe 422
+      
+      // Test invalid date format
+      val invalidDateResponse = getObligationsAndSubmissions(
+        domesticOrganisation.pillar2Id,
+        fromDate = "invalid-date"
+      )
+      println("invalidDateResponse.body: " + invalidDateResponse.body)
+      val invalidDateJson = Json.parse(invalidDateResponse.body)
+      (invalidDateJson \ "errors" \ "text").as[String] shouldBe "Request could not be processed"
+      invalidDateResponse.status shouldBe 422
+      // Test fromDate after toDate
+      val invalidDateRangeResponse = getObligationsAndSubmissions(
+        domesticOrganisation.pillar2Id,
+        fromDate = "2024-12-31",
+        toDate = "2024-01-01"
+      )
+      println("invalidDateRangeResponse.body: " + invalidDateRangeResponse.body)
+      invalidDateRangeResponse.status shouldBe 422
+      val invalidDateRangeJson = Json.parse(invalidDateRangeResponse.body)
+      (invalidDateRangeJson \ "errors" \ "text").as[String] shouldBe "Request could not be processed"
+    }
+
+    "set canAmend flag correctly based on due date" in {
+      // Create accounting period with past due date
+      val pastAccountingPeriod = AccountingPeriod(
+        startDate = LocalDate.now().minusYears(3),
+        endDate = LocalDate.now().minusYears(2).minusDays(1)
+      )
+      
+      insertSubmission(
+        domesticOrganisation.pillar2Id,
+        UKTR,
+        pastAccountingPeriod
+      )
+      
+      val response = getObligationsAndSubmissions(
+        domesticOrganisation.pillar2Id,
+        fromDate = pastAccountingPeriod.startDate.toString,
+        toDate = pastAccountingPeriod.endDate.toString
+      )
+      
+      response.status shouldBe 200
+      
+      val json = Json.parse(response.body)
+      val accountingPeriodDetails = (json \ "success" \ "accountingPeriodDetails").as[Seq[JsValue]]
+      val obligations = (accountingPeriodDetails.head \ "obligations").as[Seq[JsValue]]
+      
+      // canAmend should be false for past due date
+      (obligations.head \ "canAmend").as[Boolean] shouldBe false
+    }
+  }
+} 
+

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsControllerSpec.scala
@@ -214,16 +214,20 @@ class ObligationsAndSubmissionsControllerSpec
         route(app, createRequest()).value shouldFailWith NoAssociatedDataFound
       }
 
-      "should return NoAssociatedDataFound when the dates queried do not overlap with an accounting period" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(domesticOrganisation))
-
-        route(app, createRequest(fromDate = "2022-01-01", toDate = "2022-03-01")).value shouldFailWith NoAssociatedDataFound
-      }
-
       "should return RequestCouldNotBeProcessed for invalid date format" in {
         when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
 
         route(app, createRequest(fromDate = "invalid-date")).value shouldFailWith RequestCouldNotBeProcessed
+      }
+
+      "should return RequestCouldNotBeProcessed when fromDate is after toDate" in {
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
+
+        // Use a fromDate that is learly after toDate
+        val futureFromDate = LocalDate.now().plusYears(1).toString
+        val pastToDate     = LocalDate.now().minusYears(1).toString
+
+        route(app, createRequest(fromDate = futureFromDate, toDate = pastToDate)).value shouldFailWith RequestCouldNotBeProcessed
       }
 
       "should handle ServerErrorPlrId appropriately" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsControllerSpec.scala
@@ -27,6 +27,7 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.JsValue
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -80,6 +81,49 @@ class ObligationsAndSubmissionsControllerSpec
         )
       )
     )
+
+  def mockMultipleAccountingPeriods(): OngoingStubbing[Future[Seq[ObligationsAndSubmissionsMongoSubmission]]] = {
+    val period1 = AccountingPeriod(
+      startDate = LocalDate.of(2023, 1, 1),
+      endDate = LocalDate.of(2023, 12, 31)
+    )
+
+    val period2 = AccountingPeriod(
+      startDate = LocalDate.of(2024, 1, 1),
+      endDate = LocalDate.of(2024, 12, 31)
+    )
+
+    when(mockOasRepository.findByPillar2Id(anyString(), any[LocalDate], any[LocalDate])).thenReturn(
+      Future.successful(
+        Seq(
+          ObligationsAndSubmissionsMongoSubmission(
+            _id = new ObjectId,
+            submissionId = new ObjectId,
+            pillar2Id = validPlrId,
+            accountingPeriod = period1,
+            submissionType = UKTR,
+            submittedAt = Instant.now()
+          ),
+          ObligationsAndSubmissionsMongoSubmission(
+            _id = new ObjectId,
+            submissionId = new ObjectId,
+            pillar2Id = validPlrId,
+            accountingPeriod = period2,
+            submissionType = BTN,
+            submittedAt = Instant.now()
+          ),
+          ObligationsAndSubmissionsMongoSubmission(
+            _id = new ObjectId,
+            submissionId = new ObjectId,
+            pillar2Id = validPlrId,
+            accountingPeriod = period1, // Another submission for period1
+            submissionType = ORN,
+            submittedAt = Instant.now()
+          )
+        )
+      )
+    )
+  }
 
   override def fakeApplication(): Application =
     GuiceApplicationBuilder()
@@ -232,6 +276,79 @@ class ObligationsAndSubmissionsControllerSpec
 
       "should handle ServerErrorPlrId appropriately" in {
         route(app, createRequest(plrId = ServerErrorPlrId)).value shouldFailWith ETMPInternalServerError
+      }
+
+      "should group submissions by accounting period" in {
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
+        mockMultipleAccountingPeriods()
+
+        val result = route(app, createRequest()).value
+        status(result) mustBe OK
+
+        val jsonResponse            = contentAsJson(result)
+        val accountingPeriodDetails = (jsonResponse \ "success" \ "accountingPeriodDetails").as[Seq[JsValue]]
+
+        // Should have two accounting periods
+        accountingPeriodDetails.size mustBe 2
+
+        // First accounting period (2023) should have 2 submissions (UKTR and ORN)
+        val period1 = accountingPeriodDetails.find(period => (period \ "startDate").as[String] == "2023-01-01").value
+
+        val period1Obligations    = (period1 \ "obligations").as[Seq[JsValue]]
+        val period1GIRSubmissions = (period1Obligations(1) \ "submissions").as[Seq[JsValue]]
+        period1GIRSubmissions.size mustBe 1
+        (period1GIRSubmissions.head \ "submissionType").as[String] mustBe "ORN"
+
+        // Second accounting period (2024) should have 1 submission (BTN)
+        val period2 = accountingPeriodDetails.find(period => (period \ "startDate").as[String] == "2024-01-01").value
+
+        val period2Obligations   = (period2 \ "obligations").as[Seq[JsValue]]
+        val period2P2Submissions = (period2Obligations.head \ "submissions").as[Seq[JsValue]]
+        period2P2Submissions.size mustBe 1
+        (period2P2Submissions.head \ "submissionType").as[String] mustBe "BTN"
+      }
+
+      "should create obligations for each accounting period with correct status" in {
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
+        mockMultipleAccountingPeriods()
+
+        val result = route(app, createRequest()).value
+        status(result) mustBe OK
+
+        val jsonResponse            = contentAsJson(result)
+        val accountingPeriodDetails = (jsonResponse \ "success" \ "accountingPeriodDetails").as[Seq[JsValue]]
+
+        // First period should have Fulfilled status for Pillar2TaxReturn due to UKTR submission
+        val period1 = accountingPeriodDetails.find(period => (period \ "startDate").as[String] == "2023-01-01").value
+
+        val period1Obligations = (period1 \ "obligations").as[Seq[JsValue]]
+        (period1Obligations.head \ "status").as[String] mustBe "Fulfilled"
+        (period1Obligations.head \ "obligationType").as[String] mustBe "Pillar2TaxReturn"
+
+        // Second period should have Fulfilled status for Pillar2TaxReturn due to BTN submission
+        val period2 = accountingPeriodDetails.find(period => (period \ "startDate").as[String] == "2024-01-01").value
+
+        val period2Obligations = (period2 \ "obligations").as[Seq[JsValue]]
+        (period2Obligations.head \ "status").as[String] mustBe "Fulfilled"
+        (period2Obligations.head \ "obligationType").as[String] mustBe "Pillar2TaxReturn"
+      }
+
+      "should use organisation's default accounting period when no submissions exist" in {
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(domesticOrganisation))
+        when(mockOasRepository.findByPillar2Id(anyString(), any[LocalDate], any[LocalDate])).thenReturn(Future.successful(Seq.empty))
+
+        val result = route(app, createRequest()).value
+        status(result) mustBe OK
+
+        val jsonResponse            = contentAsJson(result)
+        val accountingPeriodDetails = (jsonResponse \ "success" \ "accountingPeriodDetails").as[Seq[JsValue]]
+
+        // Should have only one accounting period (the default one)
+        accountingPeriodDetails.size mustBe 1
+
+        // Should match the organisation's default accounting period
+        (accountingPeriodDetails.head \ "startDate").as[String] mustBe domesticOrganisation.organisation.accountingPeriod.startDate.toString
+        (accountingPeriodDetails.head \ "endDate").as[String] mustBe domesticOrganisation.organisation.accountingPeriod.endDate.toString
       }
     }
   }

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/TestOrgDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/TestOrgDataFixture.scala
@@ -51,7 +51,7 @@ trait TestOrgDataFixture extends Pillar2DataFixture {
   )
 
   val nonDomesticOrganisation: TestOrganisationWithId = TestOrganisationWithId(
-    pillar2Id = validPlrId,
+    pillar2Id = nonDomesticPlrId,
     organisation = organisationDetails.copy(orgDetails = organisationDetails.orgDetails.copy(domesticOnly = false))
   )
 }


### PR DESCRIPTION
This updates the Obligations and Submissions functionality to support organisations with submissions across multiple accounting periods. Adds a bit of future-proofness so we don't have to re-do too much of this implementation later on. 

We essentially move away from using the organisation's accounting period and construct the output purely from the submissions.

This also adds a missing Integration test suite