### PR TITLE
PIL-1630 Add Validation rules to ORN submit and amend

### DIFF
--- a/API Testing/02-orn/Amend ORN - valid request.bru
+++ b/API Testing/02-orn/Amend ORN - valid request.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 put {
-  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification
+  url: {{baseUrl}}/RESTAdapter/plr/overseas-return-notification
   body: json
   auth: none
 }

--- a/API Testing/02-orn/Get ORN - no submission.bru
+++ b/API Testing/02-orn/Get ORN - no submission.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification?accountingPeriodFrom=2025-01-01&accountingPeriodTo=2025-12-31
+  url: {{baseUrl}}/RESTAdapter/plr/overseas-return-notification?accountingPeriodFrom=2025-01-01&accountingPeriodTo=2025-12-31
 }
 
 headers {

--- a/API Testing/02-orn/Get ORN - valid request.bru
+++ b/API Testing/02-orn/Get ORN - valid request.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification?accountingPeriodFrom=2024-01-01&accountingPeriodTo=2024-12-31
+  url: {{baseUrl}}/RESTAdapter/plr/overseas-return-notification?accountingPeriodFrom=2024-01-01&accountingPeriodTo=2024-12-31
 }
 
 headers {

--- a/API Testing/02-orn/Submit ORN - 500 pillarId.bru
+++ b/API Testing/02-orn/Submit ORN - 500 pillarId.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification
+  url: {{baseUrl}}/RESTAdapter/plr/overseas-return-notification
   body: json
   auth: none
 }

--- a/API Testing/02-orn/Submit ORN - duplicate submission.bru
+++ b/API Testing/02-orn/Submit ORN - duplicate submission.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification
+  url: {{baseUrl}}/RESTAdapter/plr/overseas-return-notification
   body: json
   auth: none
 }

--- a/API Testing/02-orn/Submit ORN - invalid date.bru
+++ b/API Testing/02-orn/Submit ORN - invalid date.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification
+  url: {{baseUrl}}/RESTAdapter/plr/overseas-return-notification
   body: json
   auth: none
 }

--- a/API Testing/02-orn/Submit ORN - invalid json.bru
+++ b/API Testing/02-orn/Submit ORN - invalid json.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification
+  url: {{baseUrl}}/RESTAdapter/plr/overseas-return-notification
   body: json
   auth: none
 }

--- a/API Testing/02-orn/Submit ORN - missing header.bru
+++ b/API Testing/02-orn/Submit ORN - missing header.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification
+  url: {{baseUrl}}/RESTAdapter/plr/overseas-return-notification
   body: json
   auth: none
 }

--- a/API Testing/02-orn/Submit ORN - unauthorized.bru
+++ b/API Testing/02-orn/Submit ORN - unauthorized.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification
+  url: {{baseUrl}}/RESTAdapter/plr/overseas-return-notification
   body: json
   auth: none
 }

--- a/API Testing/02-orn/Submit ORN - valid request.bru
+++ b/API Testing/02-orn/Submit ORN - valid request.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{baseUrl}}/RESTAdapter/PLR/overseas-return-notification
+  url: {{baseUrl}}/RESTAdapter/plr/overseas-return-notification
   body: json
   auth: none
 }

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/obligationsAndSubmissions/mongo/ObligationsAndSubmissionsMongoSubmission.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/obligationsAndSubmissions/mongo/ObligationsAndSubmissionsMongoSubmission.scala
@@ -23,6 +23,7 @@ import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats.Implicits._
 import uk.gov.hmrc.pillar2externalteststub.models.BaseSubmission
 import uk.gov.hmrc.pillar2externalteststub.models.btn.BTNRequest
 import uk.gov.hmrc.pillar2externalteststub.models.obligationsAndSubmissions._
+import uk.gov.hmrc.pillar2externalteststub.models.orn.ORNRequest
 import uk.gov.hmrc.pillar2externalteststub.models.uktr.{UKTRLiabilityReturn, UKTRNilReturn}
 
 import java.time.{Instant, LocalDate}
@@ -48,6 +49,7 @@ object ObligationsAndSubmissionsMongoSubmission {
     val submissionType = submission match {
       case _: UKTRNilReturn | _: UKTRLiabilityReturn => SubmissionType.UKTR
       case _: BTNRequest => SubmissionType.BTN
+      case _: ORNRequest => SubmissionType.ORN
       case _ => throw new IllegalArgumentException("Unsupported submission type")
     }
 

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNRequest.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNRequest.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.pillar2externalteststub.models.orn
 
 import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.pillar2externalteststub.models.BaseSubmission
 
 import java.time.LocalDate
 
@@ -28,7 +29,7 @@ case class ORNRequest(
   reportingEntityName:  String,
   TIN:                  String,
   issuingCountryTIN:    String
-) {
+) extends BaseSubmission {
   def accountingPeriodValid: Boolean =
     accountingPeriodFrom.isBefore(accountingPeriodTo)
 }

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNValidationRules.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNValidationRules.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.models.orn
+
+import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError
+import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError._
+import uk.gov.hmrc.pillar2externalteststub.models.error.OrganisationNotFound
+import uk.gov.hmrc.pillar2externalteststub.services.OrganisationService
+import uk.gov.hmrc.pillar2externalteststub.validation.ValidationResult.{invalid, valid}
+import uk.gov.hmrc.pillar2externalteststub.validation.{ValidationError, ValidationRule}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class ORNValidationError(error: ETMPError) extends ValidationError {
+  override def errorCode:    String = error.code
+  override def errorMessage: String = error.message
+  override def field:        String = "ORNRequest"
+}
+
+object ORNValidationRules {
+
+  // Validation rule to check if the group is domestic only
+  def domesticOnlyRule(
+    pillar2Id:                    String
+  )(implicit organisationService: OrganisationService, ec: ExecutionContext): Future[ValidationRule[ORNRequest]] =
+    organisationService
+      .getOrganisation(pillar2Id)
+      .map { org =>
+        val isDomesticOnly = org.organisation.orgDetails.domesticOnly
+        ValidationRule[ORNRequest] { request =>
+          if (isDomesticOnly) {
+            invalid(ORNValidationError(RequestCouldNotBeProcessed))
+          } else {
+            valid(request)
+          }
+        }
+      }
+      .recover { case _: OrganisationNotFound =>
+        ValidationRule[ORNRequest](_ => invalid(ORNValidationError(NoActiveSubscription)))
+      }
+}

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNValidator.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,24 +16,22 @@
 
 package uk.gov.hmrc.pillar2externalteststub.models.orn
 
-import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.pillar2externalteststub.services.OrganisationService
+import uk.gov.hmrc.pillar2externalteststub.validation.{FailFast, ValidationRule}
 
-import java.time.LocalDate
+import scala.concurrent.{ExecutionContext, Future}
 
-case class ORNRequest(
-  accountingPeriodFrom: LocalDate,
-  accountingPeriodTo:   LocalDate,
-  filedDateGIR:         LocalDate,
-  countryGIR:           String,
-  reportingEntityName:  String,
-  TIN:                  String,
-  issuingCountryTIN:    String
-) {
-  def accountingPeriodValid: Boolean =
-    accountingPeriodFrom.isBefore(accountingPeriodTo)
-}
+object ORNValidator {
 
-object ORNRequest {
-  implicit val format: OFormat[ORNRequest] = Json.format[ORNRequest]
-
+  def ornValidator(
+    pillar2Id: String
+  )(implicit
+    organisationService: OrganisationService,
+    ec:                  ExecutionContext
+  ): Future[ValidationRule[ORNRequest]] =
+    for {
+      domesticRule <- ORNValidationRules.domesticOnlyRule(pillar2Id)
+    } yield ValidationRule.compose(
+      domesticRule
+    )(FailFast)
 }

--- a/app/uk/gov/hmrc/pillar2externalteststub/repositories/ORNSubmissionRepository.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/repositories/ORNSubmissionRepository.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.pillar2externalteststub.repositories
 
+import org.bson.types.ObjectId
 import org.mongodb.scala.model._
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
@@ -65,14 +66,17 @@ class ORNSubmissionRepository @Inject() (
       )
     ) {
 
-  def insert(pillar2Id: String, submission: ORNRequest): Future[Boolean] =
+  def insert(pillar2Id: String, submission: ORNRequest): Future[ObjectId] = {
+    val document = ORNSubmission.fromRequest(pillar2Id, submission)
+
     collection
-      .insertOne(ORNSubmission.fromRequest(pillar2Id, submission))
+      .insertOne(document)
       .toFuture()
-      .map(_ => true)
+      .map(_ => document._id)
       .recoverWith { case e: Exception =>
         Future.failed(DatabaseError(s"Failed to save ORN submission: ${e.getMessage}"))
       }
+  }
 
   def findByPillar2Id(pillar2Id: String): Future[Seq[ORNSubmission]] =
     collection

--- a/app/uk/gov/hmrc/pillar2externalteststub/services/ORNService.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/services/ORNService.scala
@@ -29,26 +29,26 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ORNService @Inject() (
-  repository:    ORNSubmissionRepository,
+  ornRepository: ORNSubmissionRepository,
   oasRepository: ObligationsAndSubmissionsRepository
 )(implicit ec:   ExecutionContext)
     extends Logging {
 
   def submitORN(pillar2Id: String, request: ORNRequest): Future[Boolean] =
-    repository.findByPillar2IdAndAccountingPeriod(pillar2Id, request.accountingPeriodFrom, request.accountingPeriodTo).flatMap {
+    ornRepository.findByPillar2IdAndAccountingPeriod(pillar2Id, request.accountingPeriodFrom, request.accountingPeriodTo).flatMap {
       case Some(_) =>
         Future.failed(TaxObligationAlreadyFulfilled)
       case None =>
-        repository.insert(pillar2Id, request).flatMap { submissionId =>
+        ornRepository.insert(pillar2Id, request).flatMap { submissionId =>
           oasRepository.insert(request, pillar2Id, submissionId)
         }
     }
 
   def amendORN(pillar2Id: String, request: ORNRequest): Future[Boolean] = {
     logger.info(s"Amending ORN for pillar2Id: $pillar2Id")
-    repository.findByPillar2IdAndAccountingPeriod(pillar2Id, request.accountingPeriodFrom, request.accountingPeriodTo).flatMap {
+    ornRepository.findByPillar2IdAndAccountingPeriod(pillar2Id, request.accountingPeriodFrom, request.accountingPeriodTo).flatMap {
       case Some(_) =>
-        repository.insert(pillar2Id, request).flatMap { submissionId =>
+        ornRepository.insert(pillar2Id, request).flatMap { submissionId =>
           oasRepository.insert(request, pillar2Id, submissionId)
         }
       case None =>
@@ -57,6 +57,6 @@ class ORNService @Inject() (
   }
 
   def getORN(pillar2Id: String, accountingPeriodFrom: LocalDate, accountingPeriodTo: LocalDate): Future[Option[ORNSubmission]] =
-    repository
+    ornRepository
       .findByPillar2IdAndAccountingPeriod(pillar2Id, accountingPeriodFrom, accountingPeriodTo)
 }

--- a/app/uk/gov/hmrc/pillar2externalteststub/services/ORNService.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/services/ORNService.scala
@@ -17,7 +17,8 @@
 package uk.gov.hmrc.pillar2externalteststub.services
 
 import play.api.Logging
-import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.{RequestCouldNotBeProcessed, TaxObligationAlreadyFulfilled}
+import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.RequestCouldNotBeProcessed
+import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.TaxObligationAlreadyFulfilled
 import uk.gov.hmrc.pillar2externalteststub.models.orn.ORNRequest
 import uk.gov.hmrc.pillar2externalteststub.models.orn.mongo.ORNSubmission
 import uk.gov.hmrc.pillar2externalteststub.repositories.ORNSubmissionRepository
@@ -33,30 +34,22 @@ class ORNService @Inject() (
     extends Logging {
 
   def submitORN(pillar2Id: String, request: ORNRequest): Future[Boolean] =
-    repository.findByPillar2Id(pillar2Id).flatMap { submissions =>
-      if (
-        submissions.exists(submission =>
-          submission.accountingPeriodFrom == request.accountingPeriodFrom && submission.accountingPeriodTo == request.accountingPeriodTo
-        )
-      ) {
-        logger.warn(s"Tax obligation already fulfilled for pillar2Id: $pillar2Id")
+    repository.findByPillar2IdAndAccountingPeriod(pillar2Id, request.accountingPeriodFrom, request.accountingPeriodTo).flatMap {
+      case Some(_) =>
         Future.failed(TaxObligationAlreadyFulfilled)
-      } else {
-        logger.info(s"Submitting new ORN for pillar2Id: $pillar2Id")
+      case None =>
         repository.insert(pillar2Id, request)
-      }
     }
 
-  def amendORN(pillar2Id: String, request: ORNRequest): Future[Boolean] =
-    repository.findByPillar2Id(pillar2Id).flatMap { submissions =>
-      if (submissions.isEmpty) {
-        logger.warn(s"No existing ORN found for pillar2Id: $pillar2Id")
-        Future.failed(RequestCouldNotBeProcessed)
-      } else {
-        logger.info(s"Amending ORN for pillar2Id: $pillar2Id")
+  def amendORN(pillar2Id: String, request: ORNRequest): Future[Boolean] = {
+    logger.info(s"Amending ORN for pillar2Id: $pillar2Id")
+    repository.findByPillar2IdAndAccountingPeriod(pillar2Id, request.accountingPeriodFrom, request.accountingPeriodTo).flatMap {
+      case Some(_) =>
         repository.insert(pillar2Id, request)
-      }
+      case None =>
+        Future.failed(RequestCouldNotBeProcessed)
     }
+  }
 
   def getORN(pillar2Id: String, accountingPeriodFrom: LocalDate, accountingPeriodTo: LocalDate): Future[Option[ORNSubmission]] =
     repository

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -8,9 +8,9 @@ PUT         /RESTAdapter/PLR/UKTaxReturn                     uk.gov.hmrc.pillar2
 POST        /RESTAdapter/PLR/below-threshold-notification    uk.gov.hmrc.pillar2externalteststub.controllers.BTNController.submitBTN
 
 GET         /RESTAdapter/plr/obligations-and-submissions     uk.gov.hmrc.pillar2externalteststub.controllers.ObligationsAndSubmissionsController.getObligationsAndSubmissions(fromDate: String, toDate: String)
-POST        /RESTAdapter/PLR/overseas-return-notification    uk.gov.hmrc.pillar2externalteststub.controllers.ORNController.submitORN
-PUT         /RESTAdapter/PLR/overseas-return-notification    uk.gov.hmrc.pillar2externalteststub.controllers.ORNController.amendORN
-GET         /RESTAdapter/PLR/overseas-return-notification    uk.gov.hmrc.pillar2externalteststub.controllers.ORNController.getORN(accountingPeriodFrom: String, accountingPeriodTo: String)
+POST        /RESTAdapter/plr/overseas-return-notification    uk.gov.hmrc.pillar2externalteststub.controllers.ORNController.submitORN
+PUT         /RESTAdapter/plr/overseas-return-notification    uk.gov.hmrc.pillar2externalteststub.controllers.ORNController.amendORN
+GET         /RESTAdapter/plr/overseas-return-notification    uk.gov.hmrc.pillar2externalteststub.controllers.ORNController.getORN(accountingPeriodFrom: String, accountingPeriodTo: String)
 
 # organisation routes
 POST        /pillar2/test/organisation/:pillar2Id                uk.gov.hmrc.pillar2externalteststub.controllers.OrganisationController.create(pillar2Id: String)

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/ORNISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/ORNISpec.scala
@@ -75,7 +75,7 @@ class ORNISpec
     )
 
     httpClient
-      .post(url"$baseUrl/RESTAdapter/PLR/overseas-return-notification")
+      .post(url"$baseUrl/RESTAdapter/plr/overseas-return-notification")
       .transform(_.withHttpHeaders(headers: _*))
       .withBody(Json.toJson(request))
       .execute[HttpResponse]
@@ -90,7 +90,7 @@ class ORNISpec
     )
 
     httpClient
-      .put(url"$baseUrl/RESTAdapter/PLR/overseas-return-notification")
+      .put(url"$baseUrl/RESTAdapter/plr/overseas-return-notification")
       .transform(_.withHttpHeaders(headers: _*))
       .withBody(Json.toJson(request))
       .execute[HttpResponse]
@@ -105,7 +105,7 @@ class ORNISpec
     )
 
     httpClient
-      .get(url"$baseUrl/RESTAdapter/PLR/overseas-return-notification?accountingPeriodFrom=$accountingPeriodFrom&accountingPeriodTo=$accountingPeriodTo")
+      .get(url"$baseUrl/RESTAdapter/plr/overseas-return-notification?accountingPeriodFrom=$accountingPeriodFrom&accountingPeriodTo=$accountingPeriodTo")
       .transform(_.withHttpHeaders(headers: _*))
       .execute[HttpResponse]
       .futureValue
@@ -208,7 +208,7 @@ class ORNISpec
       )
 
       val responseWithoutId = httpClient
-        .post(url"$baseUrl/RESTAdapter/PLR/overseas-return-notification")
+        .post(url"$baseUrl/RESTAdapter/plr/overseas-return-notification")
         .transform(_.withHttpHeaders(headers: _*))
         .withBody(Json.toJson(validORNRequest))
         .execute[HttpResponse]
@@ -291,7 +291,7 @@ class ORNISpec
       )
 
       val getResponse = httpClient
-        .get(url"$baseUrl/RESTAdapter/PLR/overseas-return-notification?accountingPeriodFrom=2024-01-01&accountingPeriodTo=2024-12-31")
+        .get(url"$baseUrl/RESTAdapter/plr/overseas-return-notification?accountingPeriodFrom=2024-01-01&accountingPeriodTo=2024-12-31")
         .transform(_.withHttpHeaders(headers: _*))
         .execute[HttpResponse]
         .futureValue

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/OrganisationISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/OrganisationISpec.scala
@@ -63,19 +63,13 @@ class OrganisationISpec
       )
       .build()
 
-  private val testOrgDetails = OrgDetails(
-    domesticOnly = false,
-    organisationName = "Test Integration Org",
-    registrationDate = LocalDate.of(2024, 1, 1)
-  )
-
   private val testAccountingPeriod = AccountingPeriod(
     startDate = LocalDate.of(2024, 1, 1),
     endDate = LocalDate.of(2024, 12, 31)
   )
 
   private val testOrganisationRequest = TestOrganisationRequest(
-    orgDetails = testOrgDetails,
+    orgDetails = orgDetails,
     accountingPeriod = testAccountingPeriod
   )
 
@@ -121,18 +115,18 @@ class OrganisationISpec
       "support the full CRUD lifecycle" in {
         val createResponse = createOrganisation(validPlrId, testOrganisationRequest)
         createResponse.status                                    shouldBe 201
-        extractOrganisationName(Json.parse(createResponse.body)) shouldBe "Test Integration Org"
+        extractOrganisationName(Json.parse(createResponse.body)) shouldBe "Test Org"
 
         val storedOrg = repository.findByPillar2Id(validPlrId).futureValue
         storedOrg.isDefined                                    shouldBe true
-        storedOrg.get.organisation.orgDetails.organisationName shouldBe "Test Integration Org"
+        storedOrg.get.organisation.orgDetails.organisationName shouldBe "Test Org"
 
         val getResponse = getOrganisation(validPlrId)
         getResponse.status                                    shouldBe 200
-        extractOrganisationName(Json.parse(getResponse.body)) shouldBe "Test Integration Org"
+        extractOrganisationName(Json.parse(getResponse.body)) shouldBe "Test Org"
 
         val updatedRequest = testOrganisationRequest.copy(
-          orgDetails = testOrgDetails.copy(organisationName = "Updated Integration Org")
+          orgDetails = orgDetails.copy(organisationName = "Updated Integration Org")
         )
         val updateResponse = updateOrganisation(validPlrId, updatedRequest)
         updateResponse.status                                    shouldBe 200

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/UKTRSubmissionISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/UKTRSubmissionISpec.scala
@@ -38,6 +38,7 @@ import uk.gov.hmrc.pillar2externalteststub.repositories.{OrganisationRepository,
 
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
+import uk.gov.hmrc.pillar2externalteststub.helpers.TestOrgDataFixture
 
 class UKTRSubmissionISpec
     extends AnyWordSpec
@@ -46,7 +47,8 @@ class UKTRSubmissionISpec
     with IntegrationPatience
     with GuiceOneServerPerSuite
     with DefaultPlayMongoRepositorySupport[UKTRMongoSubmission]
-    with UKTRDataFixture {
+    with UKTRDataFixture
+    with TestOrgDataFixture {
 
   override protected val databaseName: String = "test-uktr-submission-integration"
   private val httpClient = app.injector.instanceOf[HttpClientV2]

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/AmendUKTRControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/AmendUKTRControllerSpec.scala
@@ -33,6 +33,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.api.{Application, inject}
 import uk.gov.hmrc.pillar2externalteststub.helpers.Pillar2Helper.ServerErrorPlrId
+import uk.gov.hmrc.pillar2externalteststub.helpers.TestOrgDataFixture
 import uk.gov.hmrc.pillar2externalteststub.helpers.UKTRDataFixture
 import uk.gov.hmrc.pillar2externalteststub.models.BaseSubmission
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError._
@@ -45,7 +46,14 @@ import java.time._
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class AmendUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSuite with OptionValues with UKTRDataFixture with MockitoSugar {
+class AmendUKTRControllerSpec
+    extends AnyFreeSpec
+    with Matchers
+    with GuiceOneAppPerSuite
+    with OptionValues
+    with UKTRDataFixture
+    with MockitoSugar
+    with TestOrgDataFixture {
 
   implicit class AwaitFuture(fut: Future[Result]) {
     def shouldFailWith(expected: Throwable): Assertion = {
@@ -74,7 +82,7 @@ class AmendUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneApp
   "UK Tax Return Amendment" - {
     "when amending a UK tax return" - {
       "should return OK with success response for a valid liability amendment" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
         when(
           mockOasRepository.insert(
@@ -101,7 +109,7 @@ class AmendUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneApp
       }
 
       "should return OK with success response for a valid NIL_RETURN amendment" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
         when(mockUKTRRepository.update(argThat((submission: UKTRSubmission) => submission.isInstanceOf[UKTRNilReturn]), any[String]))
           .thenReturn(Future.successful(Right(new ObjectId())))
@@ -139,7 +147,7 @@ class AmendUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneApp
       }
 
       "should return RequestCouldNotBeProcessed when previous submission does not exist" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(None))
 
         val request = createRequest(validPlrId, Json.toJson(validRequestBody))
@@ -148,7 +156,7 @@ class AmendUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneApp
       }
 
       "should return RequestCouldNotBeProcessed when amendment to a liability return fails" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
         when(
           mockUKTRRepository.update(
@@ -163,7 +171,7 @@ class AmendUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneApp
       }
 
       "should return RequestCouldNotBeProcessed when amendment to a nil return fails" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
         when(
           mockUKTRRepository.update(
@@ -184,7 +192,7 @@ class AmendUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneApp
       }
 
       "should return ETMPBadRequest for invalid JSON structure" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
 
         val invalidJson = Json.obj("invalidField" -> "value", "anotherInvalidField" -> 123)
@@ -194,7 +202,7 @@ class AmendUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneApp
       }
 
       "should return InvalidReturn if liableEntities array is empty" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
 
         val emptyLiabilityData = validRequestBody.deepMerge(
@@ -215,7 +223,7 @@ class AmendUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneApp
       }
 
       "should return InvalidTotalLiability when amending with invalid amounts" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
 
         val invalidAmountsBody = validRequestBody.deepMerge(
@@ -231,7 +239,7 @@ class AmendUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneApp
       }
 
       "should return InvalidTotalLiability when total liability does not match sum of components in amendment" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
 
         val mismatchedTotalBody = validRequestBody.deepMerge(
@@ -246,7 +254,7 @@ class AmendUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneApp
       }
 
       "should return InvalidReturn when amending with invalid ID type" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
 
         val invalidIdTypeBody = validRequestBody.deepMerge(
@@ -272,7 +280,7 @@ class AmendUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneApp
       }
 
       "should return ETMPBadRequest when required fields are missing" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
 
         val missingRequiredFields = Json.obj(
@@ -285,7 +293,7 @@ class AmendUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneApp
       }
 
       "should return DatabaseError when database insert fails" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
         when(
           mockUKTRRepository.update(

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/SubmitUKTRControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/SubmitUKTRControllerSpec.scala
@@ -33,6 +33,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.api.{Application, inject}
 import uk.gov.hmrc.pillar2externalteststub.helpers.Pillar2Helper.ServerErrorPlrId
+import uk.gov.hmrc.pillar2externalteststub.helpers.TestOrgDataFixture
 import uk.gov.hmrc.pillar2externalteststub.helpers.UKTRDataFixture
 import uk.gov.hmrc.pillar2externalteststub.models.error.DatabaseError
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError._
@@ -45,7 +46,14 @@ import uk.gov.hmrc.pillar2externalteststub.services.OrganisationService
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class SubmitUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSuite with OptionValues with UKTRDataFixture with MockitoSugar {
+class SubmitUKTRControllerSpec
+    extends AnyFreeSpec
+    with Matchers
+    with GuiceOneAppPerSuite
+    with OptionValues
+    with UKTRDataFixture
+    with MockitoSugar
+    with TestOrgDataFixture {
 
   implicit class AwaitFuture(fut: Future[Result]) {
     def shouldFailWith(expected: Throwable): Assertion = {
@@ -74,7 +82,7 @@ class SubmitUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAp
   "UK Tax Return Submission" - {
     "when submitting a UK tax return" - {
       "should return CREATED with success response for a valid liability submission" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.insert(any[UKTRSubmission](), eqTo(validPlrId), eqTo(false))).thenReturn(Future.successful(new ObjectId()))
         when(mockOasRepository.insert(any[UKTRSubmission](), eqTo(validPlrId), any[ObjectId])).thenReturn(Future.successful(true))
 
@@ -84,7 +92,7 @@ class SubmitUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAp
       }
 
       "should return CREATED with success response for a valid NIL return submission" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.insert(any[UKTRSubmission](), eqTo(validPlrId), eqTo(false))).thenReturn(Future.successful(new ObjectId()))
         when(mockOasRepository.insert(any[UKTRSubmission](), eqTo(validPlrId), any[ObjectId])).thenReturn(Future.successful(true))
 
@@ -94,7 +102,7 @@ class SubmitUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAp
       }
 
       "should return ETMPBadRequest when the request body is invalid JSON" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
 
         val invalidJsonBody = Json.obj(
           "someField" -> "someValue"
@@ -121,7 +129,7 @@ class SubmitUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAp
       }
 
       "should return InvalidReturn when accounting period doesn't match" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
 
         val invalidAccountingPeriodBody = validRequestBody.deepMerge(
           Json.obj(
@@ -135,7 +143,7 @@ class SubmitUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAp
       }
 
       "should return InvalidReturn when liableEntities array is empty" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
 
         val emptyLiableEntitiesBody = validRequestBody.deepMerge(
           Json.obj(
@@ -169,7 +177,7 @@ class SubmitUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAp
       }
 
       "should return InvalidTotalLiability when submitting with invalid amounts" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
 
         val invalidAmountsBody: JsValue = validRequestBody.deepMerge(
           Json.obj(
@@ -185,7 +193,7 @@ class SubmitUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAp
       }
 
       "should return InvalidTotalLiability when total liability does not match sum of components" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
 
         val mismatchedTotalBody = validRequestBody.deepMerge(
           Json.obj(
@@ -200,7 +208,7 @@ class SubmitUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAp
       }
 
       "should return InvalidTotalLiability when any component is invalid" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
 
         val invalidComponentBody = validRequestBody.deepMerge(
           Json.obj(
@@ -218,7 +226,7 @@ class SubmitUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAp
       }
 
       "should return ETMPBadRequest when UKTRSubmission is neither a UKTRNilReturn nor a UKTRLiabilityReturn" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
 
         val customSubmissionBody = Json.obj(
           "accountingPeriodFrom" -> "2024-01-01",
@@ -236,7 +244,7 @@ class SubmitUKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAp
       }
 
       "should return InvalidReturn when submitting with invalid ID type" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
 
         val invalidIdTypeBody = validRequestBody.deepMerge(
           Json.obj(

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/ORNDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/ORNDataFixture.scala
@@ -19,8 +19,9 @@ package uk.gov.hmrc.pillar2externalteststub.helpers
 import org.bson.types.ObjectId
 import play.api.http.HeaderNames
 import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
-import play.api.test.Helpers.{POST, PUT}
+import play.api.test.Helpers.{GET, POST, PUT}
 import uk.gov.hmrc.pillar2externalteststub.models.orn.ORNRequest
 import uk.gov.hmrc.pillar2externalteststub.models.orn.mongo.ORNSubmission
 
@@ -54,16 +55,20 @@ trait ORNDataFixture extends Pillar2DataFixture {
   )
 
   def createSubmitRequest(plrId: String, body: JsValue): FakeRequest[JsValue] =
-    FakeRequest(POST, "/RESTAdapter/PLR/overseas-return-notification")
+    FakeRequest(POST, "/RESTAdapter/plr/overseas-return-notification")
       .withHeaders(HeaderNames.CONTENT_TYPE -> "application/json", authHeader, "X-Pillar2-Id" -> plrId)
       .withBody(body)
 
   def createAmendRequest(plrId: String, body: JsValue): FakeRequest[JsValue] =
-    FakeRequest(PUT, "/RESTAdapter/PLR/overseas-return-notification")
+    FakeRequest(PUT, "/RESTAdapter/plr/overseas-return-notification")
       .withHeaders(HeaderNames.CONTENT_TYPE -> "application/json", authHeader, "X-Pillar2-Id" -> plrId)
       .withBody(body)
 
   def createRequestWithBody(plrId: String, request: ORNRequest, isAmend: Boolean = false): FakeRequest[JsValue] =
     if (isAmend) createAmendRequest(plrId, Json.toJson(request))
     else createSubmitRequest(plrId, Json.toJson(request))
+
+  def getORNRequest(plrId: String, fromDate: String, toDate: String): FakeRequest[AnyContentAsEmpty.type] =
+    FakeRequest(GET, s"/RESTAdapter/plr/overseas-return-notification?accountingPeriodFrom=$fromDate&accountingPeriodTo=$toDate")
+      .withHeaders(authHeader, "X-Pillar2-Id" -> plrId)
 }

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/TestOrgDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/TestOrgDataFixture.scala
@@ -20,11 +20,12 @@ import org.scalatestplus.mockito.MockitoSugar.mock
 import uk.gov.hmrc.pillar2externalteststub.models.organisation._
 import uk.gov.hmrc.pillar2externalteststub.services.OrganisationService
 
+import java.time.Instant
 import java.time.LocalDate
 
 trait TestOrgDataFixture extends Pillar2DataFixture {
 
-  val mockOrgService: OrganisationService = mock[OrganisationService]
+  implicit val mockOrgService: OrganisationService = mock[OrganisationService]
 
   val orgDetails: OrgDetails = OrgDetails(
     domesticOnly = false,
@@ -38,20 +39,26 @@ trait TestOrgDataFixture extends Pillar2DataFixture {
     lastUpdated = java.time.Instant.parse("2024-01-01T00:00:00Z")
   )
 
+  val testOrgDetails: TestOrganisation = TestOrganisation(
+    orgDetails = orgDetails,
+    accountingPeriod = accountingPeriod,
+    lastUpdated = Instant.now()
+  )
+
+  val nonDomesticOrganisation: TestOrganisationWithId = TestOrganisationWithId(
+    pillar2Id = validPlrId,
+    organisation = testOrgDetails
+  )
+
+  val domesticOrganisation: TestOrganisationWithId = TestOrganisationWithId(
+    pillar2Id = validPlrId,
+    organisation = testOrgDetails.copy(orgDetails = testOrgDetails.orgDetails.copy(domesticOnly = true))
+  )
+
   val organisationWithId: TestOrganisationWithId = organisationDetails.withPillar2Id(validPlrId)
 
   val testOrganisation: TestOrganisationWithId = TestOrganisationWithId(
     pillar2Id = validPlrId,
     organisation = organisationDetails
-  )
-
-  val domesticOrganisation: TestOrganisationWithId = TestOrganisationWithId(
-    pillar2Id = validPlrId,
-    organisation = organisationDetails.copy(orgDetails = organisationDetails.orgDetails.copy(domesticOnly = true))
-  )
-
-  val nonDomesticOrganisation: TestOrganisationWithId = TestOrganisationWithId(
-    pillar2Id = nonDomesticPlrId,
-    organisation = organisationDetails.copy(orgDetails = organisationDetails.orgDetails.copy(domesticOnly = false))
   )
 }

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/TestOrgDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/TestOrgDataFixture.scala
@@ -46,7 +46,7 @@ trait TestOrgDataFixture extends Pillar2DataFixture {
   )
 
   val nonDomesticOrganisation: TestOrganisationWithId = TestOrganisationWithId(
-    pillar2Id = validPlrId,
+    pillar2Id = nonDomesticPlrId,
     organisation = testOrgDetails
   )
 

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNValidationRulesSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNValidationRulesSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.models.orn
+
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.when
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.pillar2externalteststub.helpers.ORNDataFixture
+import uk.gov.hmrc.pillar2externalteststub.helpers.TestOrgDataFixture
+import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.{NoActiveSubscription, RequestCouldNotBeProcessed}
+import uk.gov.hmrc.pillar2externalteststub.models.error.OrganisationNotFound
+import uk.gov.hmrc.pillar2externalteststub.validation.syntax._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class ORNValidationRulesSpec extends AnyWordSpec with Matchers with MockitoSugar with ScalaFutures with ORNDataFixture with TestOrgDataFixture {
+
+  "ORNValidationRules" should {
+    "domesticOnlyRule" should {
+      "reject domestic-only organisations" in {
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(domesticOrganisation))
+
+        val result = ORNValidationRules.domesticOnlyRule(validPlrId)(mockOrgService, global).flatMap { rule =>
+          Future.successful(validORNRequest.validate(rule))
+        }
+
+        whenReady(result) { validationResult =>
+          validationResult.isInvalid mustBe true
+          validationResult.toEither.left.map { errors =>
+            errors.head.asInstanceOf[ORNValidationError].error mustBe RequestCouldNotBeProcessed
+          }
+        }
+      }
+
+      "allow non-domestic organisations" in {
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
+
+        val result = ORNValidationRules.domesticOnlyRule(validPlrId)(mockOrgService, global).flatMap { rule =>
+          Future.successful(validORNRequest.validate(rule))
+        }
+
+        whenReady(result) { validationResult =>
+          validationResult.isValid mustBe true
+        }
+      }
+
+      "return NoActiveSubscription when organisation not found" in {
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.failed(OrganisationNotFound(validPlrId)))
+
+        val result = ORNValidationRules.domesticOnlyRule(validPlrId)(mockOrgService, global).flatMap { rule =>
+          Future.successful(validORNRequest.validate(rule))
+        }
+
+        whenReady(result) { validationResult =>
+          validationResult.isInvalid mustBe true
+          validationResult.toEither.left.map { errors =>
+            errors.head.asInstanceOf[ORNValidationError].error mustBe NoActiveSubscription
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNValidatorSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNValidatorSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.models.orn
+
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.when
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.pillar2externalteststub.helpers.{ORNDataFixture, TestOrgDataFixture}
+import uk.gov.hmrc.pillar2externalteststub.repositories.ORNSubmissionRepository
+import uk.gov.hmrc.pillar2externalteststub.validation.syntax._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class ORNValidatorSpec extends AnyWordSpec with Matchers with MockitoSugar with ScalaFutures with ORNDataFixture with TestOrgDataFixture {
+
+  private val mockRepository = mock[ORNSubmissionRepository]
+
+  "ORNValidator" should {
+    "validate successfully for valid data" in {
+      when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
+      when(mockRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Seq.empty))
+
+      val result = ORNValidator.ornValidator(validPlrId)(mockOrgService, global).flatMap { validator =>
+        Future.successful(validORNRequest.validate(validator))
+      }
+
+      whenReady(result) { validationResult =>
+        validationResult.isValid mustBe true
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturnSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturnSpec.scala
@@ -22,21 +22,19 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.Json
+import uk.gov.hmrc.pillar2externalteststub.helpers.TestOrgDataFixture
 import uk.gov.hmrc.pillar2externalteststub.helpers.UKTRDataFixture
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError._
-import uk.gov.hmrc.pillar2externalteststub.services.OrganisationService
 import uk.gov.hmrc.pillar2externalteststub.validation.ValidationResult.{invalid, valid}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFixture with MockitoSugar {
-
-  override implicit val mockOrgService: OrganisationService = mock[OrganisationService]
+class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFixture with MockitoSugar with TestOrgDataFixture {
 
   "UKTRLiabilityReturn validation" - {
-    when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+    when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
     val validLiabilityReturn = Json.fromJson[UKTRLiabilityReturn](validRequestBody).get
 
     "should pass validation for a valid liability return" in {
@@ -150,9 +148,6 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
     }
 
     "should fail validation when obligationMTT is true for domestic organisation" in {
-      val domesticOrganisation = testOrganisation.copy(organisation =
-        testOrganisation.organisation.copy(orgDetails = testOrganisation.organisation.orgDetails.copy(domesticOnly = true))
-      )
       when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(domesticOrganisation))
       val invalidReturn = validLiabilityReturn.copy(
         obligationMTT = true
@@ -162,7 +157,7 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
     }
 
     "should fail validation when electionUKGAAP is true for non-domestic organisation" in {
-      when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+      when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
       val invalidReturn = validLiabilityReturn.copy(
         electionUKGAAP = true
       )

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRNilReturnSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRNilReturnSpec.scala
@@ -22,19 +22,18 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.Json
+import uk.gov.hmrc.pillar2externalteststub.helpers.TestOrgDataFixture
 import uk.gov.hmrc.pillar2externalteststub.helpers.UKTRDataFixture
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError._
-import uk.gov.hmrc.pillar2externalteststub.services.OrganisationService
 import uk.gov.hmrc.pillar2externalteststub.validation.ValidationResult.{invalid, valid}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class UKTRNilReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFixture with MockitoSugar {
+class UKTRNilReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFixture with MockitoSugar with TestOrgDataFixture {
 
-  override implicit val mockOrgService: OrganisationService = mock[OrganisationService]
-  when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+  when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
 
   "UKTRNilReturn validation" - {
     val validNilReturn = Json.fromJson[UKTRNilReturn](nilReturnBody(obligationMTT = false, electionUKGAAP = false)).get
@@ -54,7 +53,7 @@ class UKTRNilReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFixture w
     }
 
     "should fail validation when electionUKGAAP is true for non-domestic organisation" in {
-      when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrganisation))
+      when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
       val invalidReturn = validNilReturn.copy(
         electionUKGAAP = true
       )

--- a/test/uk/gov/hmrc/pillar2externalteststub/repositories/ORNSubmissionRepositorySpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/repositories/ORNSubmissionRepositorySpec.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.pillar2externalteststub.repositories
 
+import org.bson.types.ObjectId
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -31,7 +32,6 @@ import uk.gov.hmrc.pillar2externalteststub.models.orn.mongo.ORNSubmission
 
 import java.time.LocalDate
 import scala.concurrent.ExecutionContext
-
 class ORNSubmissionRepositorySpec
     extends AnyWordSpec
     with Matchers
@@ -80,7 +80,7 @@ class ORNSubmissionRepositorySpec
   "insert" should {
     "successfully insert a new ORN submission" in {
       val result = repository.insert(testPillar2Id, testRequest).futureValue
-      result shouldBe true
+      result shouldBe a[ObjectId]
 
       val submissions = repository.findByPillar2Id(testPillar2Id).futureValue
       submissions.size shouldBe 1
@@ -96,21 +96,21 @@ class ORNSubmissionRepositorySpec
     }
 
     "allow submissions for same pillar2Id with different accounting periods" in {
-      repository.insert(testPillar2Id, testRequest).futureValue shouldBe true
+      repository.insert(testPillar2Id, testRequest).futureValue shouldBe a[ObjectId]
 
       val differentPeriodRequest = testRequest.copy(
         accountingPeriodFrom = LocalDate.of(2025, 1, 1),
         accountingPeriodTo = LocalDate.of(2025, 12, 31)
       )
-      repository.insert(testPillar2Id, differentPeriodRequest).futureValue shouldBe true
+      repository.insert(testPillar2Id, differentPeriodRequest).futureValue shouldBe a[ObjectId]
 
       val submissions = repository.findByPillar2Id(testPillar2Id).futureValue
       submissions.size shouldBe 2
     }
 
     "allow submissions for different pillar2Ids with same accounting period" in {
-      repository.insert(testPillar2Id, testRequest).futureValue     shouldBe true
-      repository.insert("XMPLR0000000001", testRequest).futureValue shouldBe true
+      repository.insert(testPillar2Id, testRequest).futureValue     shouldBe a[ObjectId]
+      repository.insert("XMPLR0000000001", testRequest).futureValue shouldBe a[ObjectId]
 
       val submissions1 = repository.findByPillar2Id(testPillar2Id).futureValue
       submissions1.size shouldBe 1
@@ -138,7 +138,7 @@ class ORNSubmissionRepositorySpec
         )
       )
 
-      requests.foreach(request => repository.insert(testPillar2Id, request).futureValue shouldBe true)
+      requests.foreach(request => repository.insert(testPillar2Id, request).futureValue shouldBe a[ObjectId])
 
       val submissions = repository.findByPillar2Id(testPillar2Id).futureValue
       submissions.size                      shouldBe 3
@@ -158,7 +158,7 @@ class ORNSubmissionRepositorySpec
     }
 
     "return the matching submission when one exists" in {
-      repository.insert(testPillar2Id, testRequest).futureValue shouldBe true
+      repository.insert(testPillar2Id, testRequest).futureValue shouldBe a[ObjectId]
 
       val submission = repository
         .findByPillar2IdAndAccountingPeriod(
@@ -176,13 +176,13 @@ class ORNSubmissionRepositorySpec
 
     "return the most recent submission when multiple matching submissions exist" in {
       // First insert the initial submission
-      repository.insert(testPillar2Id, testRequest).futureValue shouldBe true
+      repository.insert(testPillar2Id, testRequest).futureValue shouldBe a[ObjectId]
 
       // Then insert an updated submission with same Pillar2Id and accounting period
       val updatedRequest = testRequest.copy(
         reportingEntityName = "Updated Company Name"
       )
-      repository.insert(testPillar2Id, updatedRequest).futureValue shouldBe true
+      repository.insert(testPillar2Id, updatedRequest).futureValue shouldBe a[ObjectId]
 
       val submission = repository
         .findByPillar2IdAndAccountingPeriod(

--- a/test/uk/gov/hmrc/pillar2externalteststub/repositories/OrganisationRepositorySpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/repositories/OrganisationRepositorySpec.scala
@@ -25,6 +25,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import uk.gov.hmrc.pillar2externalteststub.config.AppConfig
+import uk.gov.hmrc.pillar2externalteststub.helpers.TestOrgDataFixture
 import uk.gov.hmrc.pillar2externalteststub.helpers.{BTNDataFixture, UKTRDataFixture}
 import uk.gov.hmrc.pillar2externalteststub.models.error.DatabaseError
 import uk.gov.hmrc.pillar2externalteststub.models.organisation._
@@ -36,7 +37,8 @@ class OrganisationRepositorySpec
     with ScalaFutures
     with IntegrationPatience
     with UKTRDataFixture
-    with BTNDataFixture {
+    with BTNDataFixture
+    with TestOrgDataFixture {
 
   override protected val databaseName: String = "test-organisation-repository"
 

--- a/test/uk/gov/hmrc/pillar2externalteststub/services/ORNServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/services/ORNServiceSpec.scala
@@ -33,27 +33,27 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 class ORNServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with ScalaFutures with ORNDataFixture {
 
-  private val mockRepository    = mock[ORNSubmissionRepository]
+  private val mockOrnRepository = mock[ORNSubmissionRepository]
   private val mockOasRepository = mock[ObligationsAndSubmissionsRepository]
-  private val service           = new ORNService(mockRepository, mockOasRepository)
+  private val service           = new ORNService(mockOrnRepository, mockOasRepository)
 
   "ORNService" should {
     "submitORN" should {
       "successfully submit a new ORN when no existing submission exists" in {
-        when(mockRepository.findByPillar2IdAndAccountingPeriod(anyString(), any[LocalDate], any[LocalDate]))
+        when(mockOrnRepository.findByPillar2IdAndAccountingPeriod(anyString(), any[LocalDate], any[LocalDate]))
           .thenReturn(Future.successful(None))
-        when(mockRepository.insert(anyString(), any[ORNRequest]())).thenReturn(Future.successful(ObjectId.get()))
+        when(mockOrnRepository.insert(anyString(), any[ORNRequest]())).thenReturn(Future.successful(ObjectId.get()))
         when(mockOasRepository.insert(any[ORNRequest](), anyString(), any[ObjectId]())).thenReturn(Future.successful(true))
 
         val result = service.submitORN(validPlrId, validORNRequest)
 
         result.futureValue mustBe true
-        verify(mockRepository).insert(validPlrId, validORNRequest)
+        verify(mockOrnRepository).insert(validPlrId, validORNRequest)
         verify(mockOasRepository).insert(eqTo(validORNRequest), eqTo(validPlrId), any[ObjectId]())
       }
 
       "fail with TaxObligationAlreadyFulfilled when a submission exists for the same accounting period" in {
-        when(mockRepository.findByPillar2IdAndAccountingPeriod(anyString(), any[LocalDate], any[LocalDate]))
+        when(mockOrnRepository.findByPillar2IdAndAccountingPeriod(anyString(), any[LocalDate], any[LocalDate]))
           .thenReturn(Future.successful(Some(ornMongoSubmission)))
 
         val result = service.submitORN(validPlrId, validORNRequest)
@@ -68,20 +68,20 @@ class ORNServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with Sc
       "successfully amend an existing ORN when a submission exists" in {
         val amendedRequest = validORNRequest.copy(reportingEntityName = "Updated Name")
 
-        when(mockRepository.findByPillar2IdAndAccountingPeriod(anyString(), any[LocalDate], any[LocalDate]))
+        when(mockOrnRepository.findByPillar2IdAndAccountingPeriod(anyString(), any[LocalDate], any[LocalDate]))
           .thenReturn(Future.successful(Some(ornMongoSubmission)))
-        when(mockRepository.insert(eqTo(validPlrId), eqTo(amendedRequest))).thenReturn(Future.successful(ObjectId.get()))
+        when(mockOrnRepository.insert(eqTo(validPlrId), eqTo(amendedRequest))).thenReturn(Future.successful(ObjectId.get()))
         when(mockOasRepository.insert(any[ORNRequest](), anyString(), any[ObjectId]())).thenReturn(Future.successful(true))
 
         val result = service.amendORN(validPlrId, amendedRequest)
 
         result.futureValue mustBe true
-        verify(mockRepository, times(1)).insert(validPlrId, amendedRequest)
+        verify(mockOrnRepository, times(1)).insert(validPlrId, amendedRequest)
         verify(mockOasRepository).insert(eqTo(amendedRequest), eqTo(validPlrId), any[ObjectId]())
       }
 
       "fail with RequestCouldNotBeProcessed when no existing submission exists" in {
-        when(mockRepository.findByPillar2IdAndAccountingPeriod(anyString(), any[LocalDate], any[LocalDate]))
+        when(mockOrnRepository.findByPillar2IdAndAccountingPeriod(anyString(), any[LocalDate], any[LocalDate]))
           .thenReturn(Future.successful(None))
 
         val result = service.amendORN(validPlrId, validORNRequest)
@@ -95,7 +95,7 @@ class ORNServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with Sc
     "getORN" should {
       "return submission when it exists for the given period" in {
         val submission = ornMongoSubmission
-        when(mockRepository.findByPillar2IdAndAccountingPeriod(anyString(), any[LocalDate], any[LocalDate]))
+        when(mockOrnRepository.findByPillar2IdAndAccountingPeriod(anyString(), any[LocalDate], any[LocalDate]))
           .thenReturn(Future.successful(Some(submission)))
 
         val result = service.getORN(validPlrId, submission.accountingPeriodFrom, submission.accountingPeriodTo)
@@ -103,7 +103,7 @@ class ORNServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with Sc
       }
 
       "return None when no submission exists for the period" in {
-        when(mockRepository.findByPillar2IdAndAccountingPeriod(anyString(), any[LocalDate], any[LocalDate]))
+        when(mockOrnRepository.findByPillar2IdAndAccountingPeriod(anyString(), any[LocalDate], any[LocalDate]))
           .thenReturn(Future.successful(None))
 
         val result = service.getORN(validPlrId, LocalDate.now(), LocalDate.now())

--- a/test/uk/gov/hmrc/pillar2externalteststub/services/ORNServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/services/ORNServiceSpec.scala
@@ -38,7 +38,8 @@ class ORNServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with Sc
   "ORNService" should {
     "submitORN" should {
       "successfully submit a new ORN when no existing submission exists" in {
-        when(mockRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Seq.empty))
+        when(mockRepository.findByPillar2IdAndAccountingPeriod(anyString(), any[LocalDate], any[LocalDate]))
+          .thenReturn(Future.successful(None))
         when(mockRepository.insert(anyString(), any[ORNRequest]())).thenReturn(Future.successful(true))
 
         val result = service.submitORN(validPlrId, validORNRequest)
@@ -48,7 +49,8 @@ class ORNServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with Sc
       }
 
       "fail with TaxObligationAlreadyFulfilled when a submission exists for the same accounting period" in {
-        when(mockRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Seq(ornMongoSubmission)))
+        when(mockRepository.findByPillar2IdAndAccountingPeriod(anyString(), any[LocalDate], any[LocalDate]))
+          .thenReturn(Future.successful(Some(ornMongoSubmission)))
 
         val result = service.submitORN(validPlrId, validORNRequest)
 
@@ -72,7 +74,8 @@ class ORNServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with Sc
       }
 
       "fail with RequestCouldNotBeProcessed when no existing submission exists" in {
-        when(mockRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Seq.empty))
+        when(mockRepository.findByPillar2IdAndAccountingPeriod(anyString(), any[LocalDate], any[LocalDate]))
+          .thenReturn(Future.successful(None))
 
         val result = service.amendORN(validPlrId, validORNRequest)
 


### PR DESCRIPTION
## Changes Made

### 1. Created Validation Framework
- Added `ORNValidationRules.scala` defining specific validation rules:
  - `domesticOnlyRule`: prevents domestic-only organisations from submitting an ORN
- Created `ORNValidator.scala` to compose these rules

### 2. Updated ORNController
- Refactored controller to use the new validation framework
- Implemented proper error handling that passes validation errors through to the error handler

### 3. Integration with Obligations and Submissions
- Updated `ORNRequest` to extend `BaseSubmission` interface
- Modified `ObligationsAndSubmissionsMongoSubmission` to handle ORN submission types
- Updated `ORNService` to store submissions in both repositories (ORN and Obligations)
- Updated `ORNSubmissionRepository` to return the ObjectId of inserted documents

### 4. Testing
- Added test specs for validation rules
- Updated existing controller tests to account for new validation behavior
- Added comprehensive tests for the ObligationsAndSubmissions integration:
  - Unit tests to verify ORNService handles repository interactions correctly
  - Integration tests to verify ORN submissions appear in both repositories
  - Integration tests to verify ORN submissions correctly affect obligations status
- Snuck in an update to our tests to all use the TestOrgDataFixture when appropriate

### Field Validation Note
Although field validation was specified in the ticket, we've not implemented detailed field validations in the external test stub. This is because:
1. Users of the stub will never directly see these validation errors
2. Field validation will be implemented properly in the submissions-api service as part of PIL-1840
