### PR TITLE
PIL-1769: Update ETMP APIs errors

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/StubErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/StubErrorHandler.scala
@@ -48,7 +48,7 @@ class StubErrorHandler extends HttpErrorHandler with Logging {
         Future.successful(ret)
       case e: ETMPError =>
         val ret = e match {
-          case Pillar2IdMissing | RequestCouldNotBeProcessed | DuplicateSubmission | NoActiveSubscription | NoAssociatedDataFound |
+          case IdMissingOrInvalid | RequestCouldNotBeProcessed | DuplicateSubmission | NoActiveSubscription | NoAssociatedDataFound |
               TaxObligationAlreadyFulfilled | InvalidReturn | InvalidDTTElection | InvalidUTPRElection | InvalidTotalLiability |
               InvalidTotalLiabilityIIR | InvalidTotalLiabilityDTT | InvalidTotalLiabilityUTPR =>
             Results.UnprocessableEntity(Json.toJson(ETMPFailureResponse(ETMPDetailedError(e.code, e.message))))

--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/package.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/package.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.pillar2externalteststub
 
 import play.api.i18n.Lang.logger
 import uk.gov.hmrc.pillar2externalteststub.helpers.Pillar2Helper.{ServerErrorPlrId, pillar2Regex}
-import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.{ETMPInternalServerError, Pillar2IdMissing}
+import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.{ETMPInternalServerError, IdMissingOrInvalid}
 
 import scala.concurrent.Future
 
@@ -34,6 +34,6 @@ package object controllers {
         Future.successful(id)
       case other =>
         logger.warn(s"Invalid Pillar2Id received: $other")
-        Future.failed(Pillar2IdMissing)
+        Future.failed(IdMissingOrInvalid)
     }
 }

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/btn/BTNValidator.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/btn/BTNValidator.scala
@@ -16,17 +16,14 @@
 
 package uk.gov.hmrc.pillar2externalteststub.models.btn
 
-import uk.gov.hmrc.pillar2externalteststub.models.btn.BTNValidationError
 import uk.gov.hmrc.pillar2externalteststub.models.common.BaseSubmissionValidationRules
-import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.RequestCouldNotBeProcessed
+import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.{NoActiveSubscription, RequestCouldNotBeProcessed}
 import uk.gov.hmrc.pillar2externalteststub.models.error.OrganisationNotFound
 import uk.gov.hmrc.pillar2externalteststub.services.OrganisationService
-import uk.gov.hmrc.pillar2externalteststub.validation.FailFast
 import uk.gov.hmrc.pillar2externalteststub.validation.ValidationResult.invalid
-import uk.gov.hmrc.pillar2externalteststub.validation.ValidationRule
+import uk.gov.hmrc.pillar2externalteststub.validation.{FailFast, ValidationRule}
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 object BTNValidator {
 
   def btnValidator(
@@ -43,6 +40,6 @@ object BTNValidator {
         )(FailFast)
       }
       .recover { case _: OrganisationNotFound =>
-        ValidationRule[BTNRequest](_ => invalid(BTNValidationError(RequestCouldNotBeProcessed)))
+        ValidationRule[BTNRequest](_ => invalid(BTNValidationError(NoActiveSubscription)))
       }
 }

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/error/ETMPError.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/error/ETMPError.scala
@@ -24,11 +24,6 @@ sealed trait ETMPError extends Exception {
 }
 
 object ETMPError {
-  case object Pillar2IdMissing extends ETMPError {
-    override val code:    String = "002"
-    override val message: String = "Pillar2 ID Missing or Invalid"
-  }
-
   case object RequestCouldNotBeProcessed extends ETMPError {
     override val code:    String = "003"
     override val message: String = "Request could not be processed"
@@ -36,12 +31,12 @@ object ETMPError {
 
   case object DuplicateSubmission extends ETMPError {
     override val code:    String = "004"
-    override val message: String = "Duplicate submission acknowledgment reference"
+    override val message: String = "Duplicate submission"
   }
 
   case object NoActiveSubscription extends ETMPError {
-    override val code:    String = "007"
-    override val message: String = "Business partner does not have an Active subscription"
+    override val code:    String = "063"
+    override val message: String = "Business Partner does not have an Active Subscription for this Regime"
   }
 
   case object NoAssociatedDataFound extends ETMPError {
@@ -52,6 +47,11 @@ object ETMPError {
   case object TaxObligationAlreadyFulfilled extends ETMPError {
     override val code:    String = "044"
     override val message: String = "Tax obligation already fulfilled"
+  }
+
+  case object IdMissingOrInvalid extends ETMPError {
+    override val code:    String = "089"
+    override val message: String = "ID number missing or invalid"
   }
 
   case object InvalidReturn extends ETMPError {

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/BTNISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/BTNISpec.scala
@@ -137,7 +137,7 @@ class BTNISpec
 
       responseWithoutId.status shouldBe 422
       val json = Json.parse(responseWithoutId.body)
-      (json \ "errors" \ "code").as[String] shouldBe "002"
+      (json \ "errors" \ "code").as[String] shouldBe "089"
 
       repository.findByPillar2Id(validPlrId).futureValue shouldBe empty
     }

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/ORNISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/ORNISpec.scala
@@ -301,7 +301,7 @@ class ORNISpec
       val response = submitORN(validPlrId, validORNRequest)
       response.status shouldBe 422
       val json = Json.parse(response.body)
-      (json \ "errors" \ "code").as[String] shouldBe "007"
+      (json \ "errors" \ "code").as[String] shouldBe "063"
     }
   }
 
@@ -349,7 +349,7 @@ class ORNISpec
       (json \ "error" \ "logID").as[String] shouldBe "C0000000000000000000000000000400"
     }
 
-    "return 422 when Pillar2 ID is missing" in {
+    "return 422 when ID number is missing" in {
       val headers = Seq(
         "Content-Type"  -> "application/json",
         "Authorization" -> "Bearer token"

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/ORNISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/ORNISpec.scala
@@ -280,7 +280,7 @@ class ORNISpec
 
       responseWithoutId.status shouldBe 422
       val json = Json.parse(responseWithoutId.body)
-      (json \ "errors" \ "code").as[String] shouldBe "002"
+      (json \ "errors" \ "code").as[String] shouldBe "089"
 
       ornRepository.findByPillar2Id(validPlrId).futureValue shouldBe empty
     }
@@ -363,7 +363,7 @@ class ORNISpec
 
       getResponse.status shouldBe 422
       val json = Json.parse(getResponse.body)
-      (json \ "errors" \ "code").as[String] shouldBe "002"
+      (json \ "errors" \ "code").as[String] shouldBe "089"
     }
 
     "return 422 when organisation does not exist" in {

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/UKTRSubmissionISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/UKTRSubmissionISpec.scala
@@ -311,7 +311,7 @@ class UKTRSubmissionISpec
 
         response.status shouldBe UNPROCESSABLE_ENTITY
         (response.json \ "errors" \ "code").as[String] shouldBe "002" 
-        (response.json \ "errors" \ "text").as[String] shouldBe "Pillar2 ID Missing or Invalid"
+        (response.json \ "errors" \ "text").as[String] shouldBe "ID number missing or invalid"
       }
 
       "return 422 when trying to amend non-existent nil return" in {
@@ -319,7 +319,7 @@ class UKTRSubmissionISpec
 
         response.status shouldBe UNPROCESSABLE_ENTITY
         (response.json \ "errors" \ "code").as[String] shouldBe "002"
-        (response.json \ "errors" \ "text").as[String] shouldBe "Pillar2 ID Missing or Invalid"
+        (response.json \ "errors" \ "text").as[String] shouldBe "ID number missing or invalid"
       }
     }
 

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/UKTRSubmissionISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/UKTRSubmissionISpec.scala
@@ -310,7 +310,7 @@ class UKTRSubmissionISpec
         val response = amendUKTR(liabilitySubmission, "nonExistentId")
 
         response.status shouldBe UNPROCESSABLE_ENTITY
-        (response.json \ "errors" \ "code").as[String] shouldBe "002" 
+        (response.json \ "errors" \ "code").as[String] shouldBe "089"
         (response.json \ "errors" \ "text").as[String] shouldBe "ID number missing or invalid"
       }
 
@@ -318,7 +318,7 @@ class UKTRSubmissionISpec
         val response = amendUKTR(nilSubmission, "nonExistentId")
 
         response.status shouldBe UNPROCESSABLE_ENTITY
-        (response.json \ "errors" \ "code").as[String] shouldBe "002"
+        (response.json \ "errors" \ "code").as[String] shouldBe "089"
         (response.json \ "errors" \ "text").as[String] shouldBe "ID number missing or invalid"
       }
     }

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/AmendUKTRControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/AmendUKTRControllerSpec.scala
@@ -128,7 +128,7 @@ class AmendUKTRControllerSpec
           .withHeaders("Content-Type" -> "application/json", authHeader)
           .withBody(Json.toJson(validRequestBody))
 
-        route(app, request).value shouldFailWith Pillar2IdMissing
+        route(app, request).value shouldFailWith IdMissingOrInvalid
       }
 
       "should return NoActiveSubscription when organisation not found" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/AmendUKTRControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/AmendUKTRControllerSpec.scala
@@ -123,7 +123,7 @@ class AmendUKTRControllerSpec
         (jsonResult \ "success" \ "processingDate").asOpt[ZonedDateTime].isDefined mustBe true
       }
 
-      "should return Pillar2IdMissing when X-Pillar2-Id header is missing" in {
+      "should return IdMissingOrInvalid when X-Pillar2-Id header is missing" in {
         val request = FakeRequest(PUT, routes.AmendUKTRController.amendUKTR.url)
           .withHeaders("Content-Type" -> "application/json", authHeader)
           .withBody(Json.toJson(validRequestBody))

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/BTNControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/BTNControllerSpec.scala
@@ -54,19 +54,19 @@ class BTNControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSui
         (json \ "success" \ "processingDate").asOpt[String].isDefined shouldBe true
       }
 
-      "should return Pillar2IdMissing when X-Pillar2-Id header is missing" in {
+      "should return IdMissingOrInvalid when X-Pillar2-Id header is missing" in {
         val request = FakeRequest(POST, "/RESTAdapter/plr/below-threshold-notification")
           .withHeaders("Content-Type" -> "application/json", authHeader)
           .withBody(validBTNRequestBody)
 
         val result = route(app, request).get
-        result shouldFailWith Pillar2IdMissing
+        result shouldFailWith IdMissingOrInvalid
       }
 
-      "should return Pillar2IdMissing when Pillar2 ID format is invalid" in {
+      "should return IdMissingOrInvalid when Pillar2 ID format is invalid" in {
         val invalidPlrId = "invalid@id"
         val result       = route(app, createRequestWithBody(invalidPlrId, validBTNRequest)).get
-        result shouldFailWith Pillar2IdMissing
+        result shouldFailWith IdMissingOrInvalid
       }
 
       "should return ETMPBadRequest when request body is invalid JSON" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/ORNControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/ORNControllerSpec.scala
@@ -64,13 +64,13 @@ class ORNControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSui
           .withBody(validRequestBody)
 
         val result = route(app, request).get
-        result shouldFailWith Pillar2IdMissing
+        result shouldFailWith IdMissingOrInvalid
       }
 
       "should return Pillar2IdMissing when Pillar2 ID format is invalid" in {
         val invalidPlrId = "invalid@id"
         val result       = route(app, createRequestWithBody(invalidPlrId, validORNRequest)).get
-        result shouldFailWith Pillar2IdMissing
+        result shouldFailWith IdMissingOrInvalid
       }
 
       "should return NoActiveSubscription when organisation not found" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/ORNControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/ORNControllerSpec.scala
@@ -58,7 +58,7 @@ class ORNControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSui
         (json \ "success" \ "formBundleNumber").asOpt[String].isDefined shouldBe true
       }
 
-      "should return Pillar2IdMissing when X-Pillar2-Id header is missing" in {
+      "should return IdMissingOrInvalid when X-Pillar2-Id header is missing" in {
         val request = FakeRequest(POST, "/RESTAdapter/plr/overseas-return-notification")
           .withHeaders("Content-Type" -> "application/json", authHeader)
           .withBody(validRequestBody)
@@ -67,7 +67,7 @@ class ORNControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSui
         result shouldFailWith IdMissingOrInvalid
       }
 
-      "should return Pillar2IdMissing when Pillar2 ID format is invalid" in {
+      "should return IdMissingOrInvalid when Pillar2 ID format is invalid" in {
         val invalidPlrId = "invalid@id"
         val result       = route(app, createRequestWithBody(invalidPlrId, validORNRequest)).get
         result shouldFailWith IdMissingOrInvalid

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/StubErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/StubErrorHandlerSpec.scala
@@ -106,15 +106,15 @@ class StubErrorHandlerSpec extends AnyWordSpec with Matchers {
       status(result) shouldBe UNPROCESSABLE_ENTITY
       val json = contentAsJson(result)
       (json \ "errors" \ "code").as[String] shouldBe "004"
-      (json \ "errors" \ "text").as[String] shouldBe "Duplicate submission acknowledgment reference"
+      (json \ "errors" \ "text").as[String] shouldBe "Duplicate submission"
     }
 
     "handle NoActiveSubscription error" in {
       val result = errorHandler.onServerError(dummyRequest, NoActiveSubscription)
       status(result) shouldBe UNPROCESSABLE_ENTITY
       val json = contentAsJson(result)
-      (json \ "errors" \ "code").as[String] shouldBe "007"
-      (json \ "errors" \ "text").as[String] shouldBe "Business partner does not have an Active subscription"
+      (json \ "errors" \ "code").as[String] shouldBe "063"
+      (json \ "errors" \ "text").as[String] shouldBe "Business Partner does not have an Active Subscription for this Regime"
     }
 
     "handle TaxObligationAlreadyFulfilled error" in {
@@ -123,6 +123,14 @@ class StubErrorHandlerSpec extends AnyWordSpec with Matchers {
       val json = contentAsJson(result)
       (json \ "errors" \ "code").as[String] shouldBe "044"
       (json \ "errors" \ "text").as[String] shouldBe "Tax obligation already fulfilled"
+    }
+
+    "handle IdMissingOrInvalid error" in {
+      val result = errorHandler.onServerError(dummyRequest, IdMissingOrInvalid)
+      status(result) shouldBe UNPROCESSABLE_ENTITY
+      val json = contentAsJson(result)
+      (json \ "errors" \ "code").as[String] shouldBe "089"
+      (json \ "errors" \ "text").as[String] shouldBe "ID number missing or invalid"
     }
 
     "handle InvalidReturn error" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/SubmitUKTRControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/SubmitUKTRControllerSpec.scala
@@ -108,7 +108,7 @@ class SubmitUKTRControllerSpec
         route(app, request).value shouldFailWith ETMPBadRequest
       }
 
-      "should return Pillar2IdMissing when X-Pillar2-Id header is missing" in {
+      "should return IdMissingOrInvalid when X-Pillar2-Id header is missing" in {
         val request = FakeRequest("POST", routes.SubmitUKTRController.submitUKTR.url)
           .withHeaders(authHeader)
           .withBody(validRequestBody)

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/SubmitUKTRControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/SubmitUKTRControllerSpec.scala
@@ -113,7 +113,7 @@ class SubmitUKTRControllerSpec
           .withHeaders(authHeader)
           .withBody(validRequestBody)
 
-        route(app, request).value shouldFailWith Pillar2IdMissing
+        route(app, request).value shouldFailWith IdMissingOrInvalid
       }
 
       "should return NoActiveSubscription when organisation not found" in {


### PR DESCRIPTION
### Changes:
002 - Pillar 2 missing or invalid → **089 - ID number missing or invalid**
004 - Duplicate submission acknowledgment reference → **004 - Duplicate submission**
007 - Business partner does not have an Active subscription → **063 - Business Partner does not have an Active Subscription for this Regime**