### PR TITLE
PIL-1780 - Update boundary check on UKTR

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/models/common/MonetaryReads.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/common/MonetaryReads.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.models.common
+
+import play.api.libs.json.{JsonValidationError, Reads}
+
+object MonetaryReads {
+  private val lBound = BigDecimal("0")
+  private val uBound = BigDecimal("9999999999999.99")
+
+  val monetaryValueReads: Reads[BigDecimal] = implicitly[Reads[BigDecimal]].filter(
+    JsonValidationError("Invalid monetary amount: must be between 0 and 9999999999999.99 with up to 2 decimal places.")
+  )(bd => bd >= lBound && bd <= uBound && bd.scale <= 2)
+}

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/Liabilities.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/Liabilities.scala
@@ -18,7 +18,8 @@ package uk.gov.hmrc.pillar2externalteststub.models.uktr
 
 import enumeratum.EnumEntry.UpperSnakecase
 import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{Json, OFormat, Reads}
+import uk.gov.hmrc.pillar2externalteststub.models.common.MonetaryReads
 
 sealed trait Liabilities
 
@@ -35,7 +36,9 @@ case class Liability(
 ) extends Liabilities
 
 object Liability {
-  implicit val liabilityDataFormat: OFormat[Liability] = Json.format[Liability]
+
+  implicit val monetaryReads: Reads[BigDecimal]  = MonetaryReads.monetaryValueReads
+  implicit val format:        OFormat[Liability] = Json.format[Liability]
 }
 
 case class LiabilityNilReturn(returnType: ReturnType) extends Liabilities
@@ -54,7 +57,8 @@ case class LiableEntity(
 )
 
 object LiableEntity {
-  implicit val format: OFormat[LiableEntity] = Json.format[LiableEntity]
+  implicit val monetaryReads: Reads[BigDecimal]     = MonetaryReads.monetaryValueReads
+  implicit val format:        OFormat[LiableEntity] = Json.format[LiableEntity]
 }
 
 sealed trait ReturnType extends EnumEntry with UpperSnakecase

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
@@ -44,7 +44,7 @@ object UKTRLiabilityReturn {
   private[uktr] val totalLiabilityRule: ValidationRule[UKTRLiabilityReturn] = ValidationRule { data =>
     val totalLiability = data.liabilities.totalLiabilityDTT + data.liabilities.totalLiabilityIIR + data.liabilities.totalLiabilityUTPR
 
-    if (UKTRValidationRules.isValidUKTRAmount(data.liabilities.totalLiability) && data.liabilities.totalLiability == totalLiability)
+    if (data.liabilities.totalLiability == totalLiability)
       valid[UKTRLiabilityReturn](data)
     else
       invalid(
@@ -57,7 +57,7 @@ object UKTRLiabilityReturn {
       acc + entity.amountOwedDTT
     }
 
-    if (UKTRValidationRules.isValidUKTRAmount(data.liabilities.totalLiabilityDTT) && data.liabilities.totalLiabilityDTT == totalDTTAmountOwed)
+    if (data.liabilities.totalLiabilityDTT == totalDTTAmountOwed)
       valid[UKTRLiabilityReturn](data)
     else
       invalid(
@@ -72,7 +72,7 @@ object UKTRLiabilityReturn {
       acc + entity.amountOwedIIR
     }
 
-    if (UKTRValidationRules.isValidUKTRAmount(data.liabilities.totalLiabilityIIR) && data.liabilities.totalLiabilityIIR == totalIIRAmountOwed)
+    if (data.liabilities.totalLiabilityIIR == totalIIRAmountOwed)
       valid[UKTRLiabilityReturn](data)
     else
       invalid(
@@ -85,7 +85,7 @@ object UKTRLiabilityReturn {
       acc + entity.amountOwedUTPR
     }
 
-    if (UKTRValidationRules.isValidUKTRAmount(data.liabilities.totalLiabilityUTPR) && data.liabilities.totalLiabilityUTPR == totalUTPRAmountOwed)
+    if (data.liabilities.totalLiabilityUTPR == totalUTPRAmountOwed)
       valid[UKTRLiabilityReturn](data)
     else
       invalid(
@@ -135,36 +135,6 @@ object UKTRLiabilityReturn {
       )
   }
 
-  private[uktr] val amountOwedDTTRule: ValidationRule[UKTRLiabilityReturn] = ValidationRule { data =>
-    if (data.liabilities.liableEntities.forall(f => UKTRValidationRules.isValidUKTRAmount(f.amountOwedDTT))) valid[UKTRLiabilityReturn](data)
-    else
-      invalid(
-        UKTRSubmissionError(
-          InvalidTotalLiabilityDTT
-        )
-      )
-  }
-
-  private[uktr] val amountOwedIIRRule: ValidationRule[UKTRLiabilityReturn] = ValidationRule { data =>
-    if (data.liabilities.liableEntities.forall(f => UKTRValidationRules.isValidUKTRAmount(f.amountOwedIIR))) valid[UKTRLiabilityReturn](data)
-    else
-      invalid(
-        UKTRSubmissionError(
-          InvalidTotalLiabilityIIR
-        )
-      )
-  }
-
-  private[uktr] val amountOwedUTPRRule: ValidationRule[UKTRLiabilityReturn] = ValidationRule { data =>
-    if (data.liabilities.liableEntities.forall(f => UKTRValidationRules.isValidUKTRAmount(f.amountOwedUTPR))) valid[UKTRLiabilityReturn](data)
-    else
-      invalid(
-        UKTRSubmissionError(
-          InvalidTotalLiabilityUTPR
-        )
-      )
-  }
-
   def uktrSubmissionValidator(
     plrReference:                 String
   )(implicit organisationService: OrganisationService, ec: ExecutionContext): Future[ValidationRule[UKTRLiabilityReturn]] =
@@ -182,10 +152,7 @@ object UKTRLiabilityReturn {
           totalLiabilityUTPRRule,
           ukChargeableEntityNameRule,
           idTypeRule,
-          idValueRule,
-          amountOwedDTTRule,
-          amountOwedIIRRule,
-          amountOwedUTPRRule
+          idValueRule
         )(FailFast)
       }
       .recover { case _: OrganisationNotFound =>

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRValidationRules.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRValidationRules.scala
@@ -23,13 +23,6 @@ import uk.gov.hmrc.pillar2externalteststub.validation.ValidationRule
 
 object UKTRValidationRules {
 
-  val boundaryUKTRAmount: BigDecimal = BigDecimal("9999999999999.99")
-
-  def isValidUKTRAmount(number: BigDecimal): Boolean =
-    number >= 0 &&
-      number <= boundaryUKTRAmount &&
-      number.scale <= 2
-
   // Common validation for obligationMTT - checks if domestic organisations can have obligationMTT set to true
   def obligationMTTRule[T <: UKTRSubmission](
     org: TestOrganisationWithId

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/UKTRSubmissionISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/UKTRSubmissionISpec.scala
@@ -386,9 +386,9 @@ class UKTRSubmissionISpec
         response.status shouldBe UNPROCESSABLE_ENTITY
       }
 
-      "return 422 for invalid amounts" in {
+      "return 400 for invalid amounts" in {
         val response = submitCustomPayload(invalidAmountsJson, validPlrId)
-        response.status shouldBe UNPROCESSABLE_ENTITY
+        response.status shouldBe BAD_REQUEST
       }
 
       "return 422 for invalid ID type" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/AmendUKTRControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/AmendUKTRControllerSpec.scala
@@ -215,23 +215,25 @@ class AmendUKTRControllerSpec
         route(app, request).value shouldFailWith InvalidReturn
       }
 
-      "should return InvalidTotalLiability when amending with invalid amounts" in {
+      "should return ETMPBadRequest when amending with invalid amounts" in {
         when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
 
-        val invalidAmountsBody = validRequestBody.deepMerge(
+        val invalidAmountsBody: JsValue = validRequestBody.deepMerge(
           Json.obj(
             "liabilities" -> Json.obj(
-              "totalLiability"    -> -500,
-              "totalLiabilityDTT" -> 10000000000000.99
+              "totalLiability"    -> -500.00,
+              "totalLiabilityDTT" -> 10000000000000.00
             )
           )
         )
 
-        route(app, createRequest(validPlrId, invalidAmountsBody)).value shouldFailWith InvalidTotalLiability
+        val request = createRequest(validPlrId, invalidAmountsBody)
+
+        route(app, request).value shouldFailWith ETMPBadRequest
       }
 
-      "should return InvalidTotalLiability when total liability does not match sum of components in amendment" in {
+      "should return InvalidTotalLiability when total liability does not match sum of components" in {
         when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
 
@@ -244,6 +246,60 @@ class AmendUKTRControllerSpec
         )
 
         route(app, createRequest(validPlrId, mismatchedTotalBody)).value shouldFailWith InvalidTotalLiability
+      }
+
+      "should return ETMPBadRequest when any component is invalid (e.g., negative)" in {
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
+        when(mockUKTRRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
+
+        val invalidComponentBody = validRequestBody.deepMerge(
+          Json.obj(
+            "liabilities" -> Json.obj(
+              "totalLiabilityDTT"  -> 5000.99,
+              "totalLiabilityIIR"  -> -100.00, // This negative value should cause BadRequest
+              "totalLiabilityUTPR" -> 10000.99,
+              "totalLiability"     -> 15001.98 // Provide valid total
+            )
+          )
+        )
+
+        val request = createRequest(validPlrId, invalidComponentBody)
+
+        route(app, request).value shouldFailWith ETMPBadRequest
+      }
+
+      "should return ETMPBadRequest when any amount has incorrect scale" in {
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
+        when(mockUKTRRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
+
+        val invalidScaleBody = validRequestBody.deepMerge(
+          Json.obj(
+            "liabilities" -> Json.obj(
+              "totalLiability" -> 15001.987 // Too many decimal places
+            )
+          )
+        )
+        val request = createRequest(validPlrId, invalidScaleBody)
+
+        route(app, request).value shouldFailWith ETMPBadRequest
+      }
+
+      "should return ETMPBadRequest when any liable entity amount is invalid" in {
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
+        when(mockUKTRRepository.findByPillar2Id(anyString())).thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
+
+        val invalidEntityAmountBody = validRequestBody.deepMerge(
+          Json.obj(
+            "liabilities" -> Json.obj(
+              "liableEntities" -> Json.arr(
+                validLiableEntity.as[JsObject] ++ Json.obj("amountOwedDTT" -> -1.00) // Invalid amount in entity
+              )
+            )
+          )
+        )
+        val request = createRequest(validPlrId, invalidEntityAmountBody)
+
+        route(app, request).value shouldFailWith ETMPBadRequest
       }
 
       "should return InvalidReturn when amending with invalid ID type" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/SubmitUKTRControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/SubmitUKTRControllerSpec.scala
@@ -178,8 +178,8 @@ class SubmitUKTRControllerSpec
         val invalidAmountsBody: JsValue = validRequestBody.deepMerge(
           Json.obj(
             "liabilities" -> Json.obj(
-              "totalLiability"    -> -500.00,
-              "totalLiabilityDTT" -> 10000000000000.00
+              "totalLiability"    -> -500,
+              "totalLiabilityDTT" -> 10000000000000.99
             )
           )
         )
@@ -203,7 +203,7 @@ class SubmitUKTRControllerSpec
         route(app, request).value shouldFailWith InvalidTotalLiability
       }
 
-      "should return ETMPBadRequest when any component is invalid (e.g., negative)" in {
+      "should return ETMPBadRequest when any component is invalid" in {
         when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
 
         val invalidComponentBody = validRequestBody.deepMerge(
@@ -212,43 +212,11 @@ class SubmitUKTRControllerSpec
               "totalLiabilityDTT"  -> 5000.99,
               "totalLiabilityIIR"  -> -100.00,
               "totalLiabilityUTPR" -> 10000.99,
-              "totalLiability"     -> 15001.98
+              "totalLiability"     -> 15901.98 // Sum would be correct if IIR wasn't negative
             )
           )
         )
         val request = createRequest(validPlrId, invalidComponentBody)
-
-        route(app, request).value shouldFailWith ETMPBadRequest
-      }
-
-      "should return ETMPBadRequest when any amount has incorrect scale" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
-
-        val invalidScaleBody = validRequestBody.deepMerge(
-          Json.obj(
-            "liabilities" -> Json.obj(
-              "totalLiability" -> 15001.987
-            )
-          )
-        )
-        val request = createRequest(validPlrId, invalidScaleBody)
-
-        route(app, request).value shouldFailWith ETMPBadRequest
-      }
-
-      "should return ETMPBadRequest when any liable entity amount is invalid" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
-
-        val invalidEntityAmountBody = validRequestBody.deepMerge(
-          Json.obj(
-            "liabilities" -> Json.obj(
-              "liableEntities" -> Json.arr(
-                validLiableEntity.as[JsObject] ++ Json.obj("amountOwedDTT" -> -1.00)
-              )
-            )
-          )
-        )
-        val request = createRequest(validPlrId, invalidEntityAmountBody)
 
         route(app, request).value shouldFailWith ETMPBadRequest
       }

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/common/MonetaryReadsSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/common/MonetaryReadsSpec.scala
@@ -22,8 +22,10 @@ import play.api.libs.json._
 
 class MonetaryReadsSpec extends AnyFreeSpec with Matchers {
 
-  val reads           = MonetaryReads.monetaryValueReads
-  val validationError: JsonValidationError = JsonValidationError("Invalid monetary amount: must be between 0 and 9999999999999.99 with up to 2 decimal places.")
+  val reads = MonetaryReads.monetaryValueReads
+  val validationError: JsonValidationError = JsonValidationError(
+    "Invalid monetary amount: must be between 0 and 9999999999999.99 with up to 2 decimal places."
+  )
 
   "MonetaryReads" - {
 

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/common/MonetaryReadsSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/common/MonetaryReadsSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.models.common
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import play.api.libs.json._
+
+class MonetaryReadsSpec extends AnyFreeSpec with Matchers {
+
+  val reads           = MonetaryReads.monetaryValueReads
+  val validationError: JsonValidationError = JsonValidationError("Invalid monetary amount: must be between 0 and 9999999999999.99 with up to 2 decimal places.")
+
+  "MonetaryReads" - {
+
+    "must successfully read valid monetary values" - {
+      "when value is 0" in {
+        reads.reads(JsNumber(BigDecimal(0))) mustBe JsSuccess(BigDecimal(0))
+      }
+      "when value is 0.00" in {
+        reads.reads(JsNumber(BigDecimal(0.00))) mustBe JsSuccess(BigDecimal(0.00))
+      }
+      "when value is the upper bound (9999999999999.99)" in {
+        val upperBound = BigDecimal("9999999999999.99")
+        reads.reads(JsNumber(upperBound)) mustBe JsSuccess(upperBound)
+      }
+      "when value is a typical amount (123.45)" in {
+        reads.reads(JsNumber(BigDecimal(123.45))) mustBe JsSuccess(BigDecimal(123.45))
+      }
+      "when value has 1 decimal place" in {
+        reads.reads(JsNumber(BigDecimal(123.4))) mustBe JsSuccess(BigDecimal(123.4))
+      }
+    }
+
+    "must fail to read invalid monetary values" - {
+      "when value is negative (-0.01)" in {
+        reads.reads(JsNumber(BigDecimal(-0.01))) mustBe JsError(validationError)
+      }
+      "when value is slightly above the upper bound (10000000000000.00)" in {
+        val justOver = BigDecimal("10000000000000.00")
+        reads.reads(JsNumber(justOver)) mustBe JsError(validationError)
+      }
+      "when value has more than 2 decimal places (0.123)" in {
+        reads.reads(JsNumber(BigDecimal(0.123))) mustBe JsError(validationError)
+      }
+      "when value is the upper bound but has too many decimal places (9999999999999.991)" in {
+        val upperBoundWrongScale = BigDecimal("9999999999999.991")
+        reads.reads(JsNumber(upperBoundWrongScale)) mustBe JsError(validationError)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR refactors the validation for monetary fields (like liabilities and amounts owed) to occur during JSON deserialization rather than as a separate business rule validation step.

**Changes:**

*   Introduced `MonetaryReads.monetaryValueReads`, a custom Play JSON `Reads[BigDecimal]`, which ensures values are non-negative, within the maximum allowed limit (`9999999999999.99`), and have a maximum scale of 2 decimal places.
*   Applied this custom `Reads` to the relevant `BigDecimal` fields in the `Liability` and `LiableEntity` models. This implicitly uses the `monetaryValueReads` whenever these models are parsed from JSON.
*   Removed the now-redundant `isValidUKTRAmount` checks and associated validation rules (`amountOwed*Rule`) from `UKTRLiabilityReturn` and `UKTRValidationRules`. The validation of individual amounts is now handled by `MonetaryReads`.
*   Updated `SubmitUKTRControllerSpec` and `AmendUKTRControllerSpec`: Tests that previously expected 422 (`InvalidTotalLiability*`) errors for out-of-bounds or incorrectly scaled amounts now expect a 400 (`ETMPBadRequest`), reflecting the earlier failure during JSON parsing.
*   Added `MonetaryReadsSpec` to thoroughly test the boundary conditions of the new custom `Reads`.
