### PR TITLE
PIL-1826: Domestic-only obligationMTT & totals validation

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/models/error/ETMPError.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/error/ETMPError.scala
@@ -56,7 +56,7 @@ object ETMPError {
 
   case object InvalidReturn extends ETMPError {
     override val code:    String = "093"
-    override val message: String = "Invalid return"
+    override val message: String = "Invalid Return"
   }
 
   case object InvalidDTTElection extends ETMPError {

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/error/ETMPError.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/error/ETMPError.scala
@@ -61,32 +61,32 @@ object ETMPError {
 
   case object InvalidDTTElection extends ETMPError {
     override val code:    String = "094"
-    override val message: String = "Invalid DTT election"
+    override val message: String = "Invalid DTT Election"
   }
 
   case object InvalidUTPRElection extends ETMPError {
     override val code:    String = "095"
-    override val message: String = "Invalid UTPR election"
+    override val message: String = "Invalid UTPR Election"
   }
 
   case object InvalidTotalLiability extends ETMPError {
     override val code:    String = "096"
-    override val message: String = "Invalid total liability"
+    override val message: String = "Invalid Total Liability"
   }
 
   case object InvalidTotalLiabilityIIR extends ETMPError {
     override val code:    String = "097"
-    override val message: String = "Invalid total liability IIR"
+    override val message: String = "Invalid Total Liability IIR"
   }
 
   case object InvalidTotalLiabilityDTT extends ETMPError {
     override val code:    String = "098"
-    override val message: String = "Invalid total liability DTT"
+    override val message: String = "Invalid Total Liability DTT"
   }
 
   case object InvalidTotalLiabilityUTPR extends ETMPError {
     override val code:    String = "099"
-    override val message: String = "Invalid total liability UTPR"
+    override val message: String = "Invalid Total Liability UTPR"
   }
 
   case object ETMPBadRequest extends ETMPError {

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/StubErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/StubErrorHandlerSpec.scala
@@ -138,7 +138,7 @@ class StubErrorHandlerSpec extends AnyWordSpec with Matchers {
       status(result) shouldBe UNPROCESSABLE_ENTITY
       val json = contentAsJson(result)
       (json \ "errors" \ "code").as[String] shouldBe "093"
-      (json \ "errors" \ "text").as[String] shouldBe "Invalid return"
+      (json \ "errors" \ "text").as[String] shouldBe "Invalid Return"
     }
 
     "handle InvalidDTTElection error" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/StubErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/StubErrorHandlerSpec.scala
@@ -146,7 +146,7 @@ class StubErrorHandlerSpec extends AnyWordSpec with Matchers {
       status(result) shouldBe UNPROCESSABLE_ENTITY
       val json = contentAsJson(result)
       (json \ "errors" \ "code").as[String] shouldBe "094"
-      (json \ "errors" \ "text").as[String] shouldBe "Invalid DTT election"
+      (json \ "errors" \ "text").as[String] shouldBe "Invalid DTT Election"
     }
 
     "handle InvalidUTPRElection error" in {
@@ -154,7 +154,7 @@ class StubErrorHandlerSpec extends AnyWordSpec with Matchers {
       status(result) shouldBe UNPROCESSABLE_ENTITY
       val json = contentAsJson(result)
       (json \ "errors" \ "code").as[String] shouldBe "095"
-      (json \ "errors" \ "text").as[String] shouldBe "Invalid UTPR election"
+      (json \ "errors" \ "text").as[String] shouldBe "Invalid UTPR Election"
     }
 
     "handle InvalidTotalLiability error" in {
@@ -162,7 +162,7 @@ class StubErrorHandlerSpec extends AnyWordSpec with Matchers {
       status(result) shouldBe UNPROCESSABLE_ENTITY
       val json = contentAsJson(result)
       (json \ "errors" \ "code").as[String] shouldBe "096"
-      (json \ "errors" \ "text").as[String] shouldBe "Invalid total liability"
+      (json \ "errors" \ "text").as[String] shouldBe "Invalid Total Liability"
     }
 
     "handle InvalidTotalLiabilityIIR error" in {
@@ -170,7 +170,7 @@ class StubErrorHandlerSpec extends AnyWordSpec with Matchers {
       status(result) shouldBe UNPROCESSABLE_ENTITY
       val json = contentAsJson(result)
       (json \ "errors" \ "code").as[String] shouldBe "097"
-      (json \ "errors" \ "text").as[String] shouldBe "Invalid total liability IIR"
+      (json \ "errors" \ "text").as[String] shouldBe "Invalid Total Liability IIR"
     }
 
     "handle InvalidTotalLiabilityDTT error" in {
@@ -178,7 +178,7 @@ class StubErrorHandlerSpec extends AnyWordSpec with Matchers {
       status(result) shouldBe UNPROCESSABLE_ENTITY
       val json = contentAsJson(result)
       (json \ "errors" \ "code").as[String] shouldBe "098"
-      (json \ "errors" \ "text").as[String] shouldBe "Invalid total liability DTT"
+      (json \ "errors" \ "text").as[String] shouldBe "Invalid Total Liability DTT"
     }
 
     "handle InvalidTotalLiabilityUTPR error" in {
@@ -186,7 +186,7 @@ class StubErrorHandlerSpec extends AnyWordSpec with Matchers {
       status(result) shouldBe UNPROCESSABLE_ENTITY
       val json = contentAsJson(result)
       (json \ "errors" \ "code").as[String] shouldBe "099"
-      (json \ "errors" \ "text").as[String] shouldBe "Invalid total liability UTPR"
+      (json \ "errors" \ "text").as[String] shouldBe "Invalid Total Liability UTPR"
     }
 
     "handle ETMPBadRequest error" in {


### PR DESCRIPTION
Adds more business validation rules to submissions from domestic-only organisations (best summarised in the ticket [PIL-1826](https://jira.tools.tax.service.gov.uk/browse/PIL-1826)).