### PR TITLE
PIL-1818 Implement Duplicate Submission Error Handling for UKTR and BTN

### DIFF
--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/ObligationsAndSubmissionsDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/ObligationsAndSubmissionsDataFixture.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.helpers
+
+import org.bson.types.ObjectId
+import uk.gov.hmrc.pillar2externalteststub.models.obligationsAndSubmissions.SubmissionType._
+import uk.gov.hmrc.pillar2externalteststub.models.obligationsAndSubmissions.mongo.{AccountingPeriod, ObligationsAndSubmissionsMongoSubmission}
+
+import java.time.Instant
+
+trait ObligationsAndSubmissionsDataFixture extends Pillar2DataFixture {
+
+  val btnObligationsAndSubmissionsMongoSubmission: ObligationsAndSubmissionsMongoSubmission = ObligationsAndSubmissionsMongoSubmission(
+    _id = new ObjectId(),
+    submissionId = new ObjectId(),
+    pillar2Id = validPlrId,
+    accountingPeriod = AccountingPeriod(accountingPeriod.startDate, accountingPeriod.endDate),
+    submissionType = BTN,
+    submittedAt = Instant.now()
+  )
+
+  val uktrObligationsAndSubmissionsMongoSubmission: ObligationsAndSubmissionsMongoSubmission = ObligationsAndSubmissionsMongoSubmission(
+    _id = new ObjectId(),
+    submissionId = new ObjectId(),
+    pillar2Id = validPlrId,
+    accountingPeriod = AccountingPeriod(accountingPeriod.startDate, accountingPeriod.endDate),
+    submissionType = UKTR,
+    submittedAt = Instant.now()
+  )
+
+  val ornObligationsAndSubmissionsMongoSubmission: ObligationsAndSubmissionsMongoSubmission = ObligationsAndSubmissionsMongoSubmission(
+    _id = new ObjectId(),
+    submissionId = new ObjectId(),
+    pillar2Id = validPlrId,
+    accountingPeriod = AccountingPeriod(accountingPeriod.startDate, accountingPeriod.endDate),
+    submissionType = ORN,
+    submittedAt = Instant.now()
+  )
+
+  val olderBtnObligationsAndSubmissionsMongoSubmission: ObligationsAndSubmissionsMongoSubmission = ObligationsAndSubmissionsMongoSubmission(
+    _id = new ObjectId(),
+    submissionId = new ObjectId(),
+    pillar2Id = validPlrId,
+    accountingPeriod = AccountingPeriod(accountingPeriod.startDate, accountingPeriod.endDate),
+    submissionType = BTN,
+    submittedAt = Instant.now().minusSeconds(3600) // 1 hour older
+  )
+
+  val differentPeriodBtnObligationsAndSubmissionsMongoSubmission: ObligationsAndSubmissionsMongoSubmission = ObligationsAndSubmissionsMongoSubmission(
+    _id = new ObjectId(),
+    submissionId = new ObjectId(),
+    pillar2Id = validPlrId,
+    accountingPeriod = AccountingPeriod(
+      accountingPeriod.startDate.plusYears(1),
+      accountingPeriod.endDate.plusYears(1)
+    ),
+    submissionType = BTN,
+    submittedAt = Instant.now()
+  )
+} 

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/ObligationsAndSubmissionsDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/ObligationsAndSubmissionsDataFixture.scala
@@ -71,4 +71,4 @@ trait ObligationsAndSubmissionsDataFixture extends Pillar2DataFixture {
     submissionType = BTN,
     submittedAt = Instant.now()
   )
-} 
+}

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/UKTRDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/UKTRDataFixture.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.pillar2externalteststub.helpers
 
 import org.bson.types.ObjectId
 import play.api.libs.json.{JsObject, Json}
-import uk.gov.hmrc.pillar2externalteststub.models.uktr.UKTRSubmission
 import uk.gov.hmrc.pillar2externalteststub.models.uktr.mongo.UKTRMongoSubmission
+import uk.gov.hmrc.pillar2externalteststub.models.uktr.{ReturnType, UKTRSubmission}
 
 import java.time.Instant
 import scala.util.matching.Regex
@@ -473,5 +473,89 @@ trait UKTRDataFixture extends Pillar2DataFixture with TestOrgDataFixture {
     chargeReference = Some(chargeReference),
     data = Json.fromJson[UKTRSubmission](validRequestBody).get,
     submittedAt = Instant.now()
+  )
+
+  val correctNilReturnJson: JsObject = Json.obj(
+    "accountingPeriodFrom" -> accountingPeriod.startDate.toString,
+    "accountingPeriodTo"   -> accountingPeriod.endDate.toString,
+    "obligationMTT"        -> false,
+    "electionUKGAAP"       -> false,
+    "liabilities" -> Json.obj(
+      "returnType" -> ReturnType.NIL_RETURN.toString
+    )
+  )
+
+  val invalidAccountingPeriodJson: JsObject = Json.obj(
+    "accountingPeriodFrom" -> "2023-01-01",
+    "accountingPeriodTo"   -> "2023-12-31",
+    "obligationMTT"        -> false,
+    "electionUKGAAP"       -> false,
+    "liabilities" -> Json.obj(
+      "electionDTTSingleMember"  -> false,
+      "electionUTPRSingleMember" -> false,
+      "numberSubGroupDTT"        -> 4,
+      "numberSubGroupUTPR"       -> 5,
+      "totalLiability"           -> 10000.99,
+      "totalLiabilityDTT"        -> 5000.99,
+      "totalLiabilityIIR"        -> 4000,
+      "totalLiabilityUTPR"       -> 10000.99,
+      "liableEntities"           -> Json.arr(validLiableEntity)
+    )
+  )
+
+  val emptyLiableEntitiesJson: JsObject = Json.obj(
+    "accountingPeriodFrom" -> accountingPeriod.startDate.toString,
+    "accountingPeriodTo"   -> accountingPeriod.endDate.toString,
+    "obligationMTT"        -> false,
+    "electionUKGAAP"       -> false,
+    "liabilities" -> Json.obj(
+      "electionDTTSingleMember"  -> false,
+      "electionUTPRSingleMember" -> false,
+      "numberSubGroupDTT"        -> 4,
+      "numberSubGroupUTPR"       -> 5,
+      "totalLiability"           -> 10000.99,
+      "totalLiabilityDTT"        -> 5000.99,
+      "totalLiabilityIIR"        -> 4000,
+      "totalLiabilityUTPR"       -> 10000.99,
+      "liableEntities"           -> Json.arr()
+    )
+  )
+
+  val invalidAmountsJson: JsObject = Json.obj(
+    "accountingPeriodFrom" -> accountingPeriod.startDate.toString,
+    "accountingPeriodTo"   -> accountingPeriod.endDate.toString,
+    "obligationMTT"        -> false,
+    "electionUKGAAP"       -> false,
+    "liabilities" -> Json.obj(
+      "electionDTTSingleMember"  -> false,
+      "electionUTPRSingleMember" -> false,
+      "numberSubGroupDTT"        -> 4,
+      "numberSubGroupUTPR"       -> 5,
+      "totalLiability"           -> -500,
+      "totalLiabilityDTT"        -> 10000000000000.99,
+      "totalLiabilityIIR"        -> 4000,
+      "totalLiabilityUTPR"       -> 10000.99,
+      "liableEntities"           -> Json.arr(validLiableEntity)
+    )
+  )
+
+  val invalidIdTypeJson: JsObject = Json.obj(
+    "accountingPeriodFrom" -> accountingPeriod.startDate.toString,
+    "accountingPeriodTo"   -> accountingPeriod.endDate.toString,
+    "obligationMTT"        -> false,
+    "electionUKGAAP"       -> false,
+    "liabilities" -> Json.obj(
+      "electionDTTSingleMember"  -> false,
+      "electionUTPRSingleMember" -> false,
+      "numberSubGroupDTT"        -> 4,
+      "numberSubGroupUTPR"       -> 5,
+      "totalLiability"           -> 10000.99,
+      "totalLiabilityDTT"        -> 5000.99,
+      "totalLiabilityIIR"        -> 4000,
+      "totalLiabilityUTPR"       -> 10000.99,
+      "liableEntities" -> Json.arr(
+        validLiableEntity.as[JsObject] ++ Json.obj("idType" -> "INVALID")
+      )
+    )
   )
 }

--- a/test/uk/gov/hmrc/pillar2externalteststub/services/BTNServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/services/BTNServiceSpec.scala
@@ -18,22 +18,39 @@ package uk.gov.hmrc.pillar2externalteststub.services
 
 import org.bson.types.ObjectId
 import org.mockito.ArgumentMatchers.{any, anyString, eq => eqTo}
+import org.mockito.Mockito.reset
 import org.mockito.Mockito.{never, verify, when}
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
-import uk.gov.hmrc.pillar2externalteststub.helpers.{BTNDataFixture, TestOrgDataFixture}
+import uk.gov.hmrc.pillar2externalteststub.helpers.{BTNDataFixture, ObligationsAndSubmissionsDataFixture, TestOrgDataFixture}
 import uk.gov.hmrc.pillar2externalteststub.models.btn.BTNRequest
-import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.DuplicateSubmission
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.RequestCouldNotBeProcessed
+import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.TaxObligationAlreadyFulfilled
 import uk.gov.hmrc.pillar2externalteststub.repositories.{BTNSubmissionRepository, ObligationsAndSubmissionsRepository}
 
 import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class BTNServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with ScalaFutures with BTNDataFixture with TestOrgDataFixture {
+class BTNServiceSpec
+    extends AnyWordSpec
+    with Matchers
+    with MockitoSugar
+    with ScalaFutures
+    with BTNDataFixture
+    with TestOrgDataFixture
+    with ObligationsAndSubmissionsDataFixture
+    with BeforeAndAfterEach {
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockBtnRepository)
+    reset(mockOasRepository)
+    reset(mockOrgService)
+  }
 
   private val mockBtnRepository = mock[BTNSubmissionRepository]
   private val mockOasRepository = mock[ObligationsAndSubmissionsRepository]
@@ -41,38 +58,86 @@ class BTNServiceSpec extends AnyWordSpec with Matchers with MockitoSugar with Sc
 
   "BTNService" should {
     "submitBTN" should {
-      "fail with DuplicateSubmission when a BTN submission exists" in {
-        when(mockBtnRepository.findByPillar2Id(anyString()))
-          .thenReturn(Future.successful(Seq(btnMongoSubmission)))
+      "fail with TaxObligationAlreadyFulfilled when a BTN submission is the most recent submission for the period" in {
+        when(mockOasRepository.findByPillar2Id(anyString(), any[LocalDate], any[LocalDate]))
+          .thenReturn(Future.successful(Seq(btnObligationsAndSubmissionsMongoSubmission)))
         when(mockOrgService.getOrganisation(anyString()))
           .thenReturn(Future.successful(domesticOrganisation))
 
         val result = service.submitBTN(validPlrId, validBTNRequest)
 
-        result shouldFailWith DuplicateSubmission
+        result shouldFailWith TaxObligationAlreadyFulfilled
 
         verify(mockBtnRepository, never).insert(anyString(), any[BTNRequest]())
       }
 
       "fail with RequestCouldNotBeProcessed for invalid requests" in {
-        // Setup
+        when(mockOrgService.getOrganisation(anyString()))
+          .thenReturn(Future.successful(domesticOrganisation))
         val invalidRequest = validBTNRequest.copy(
           accountingPeriodFrom = LocalDate.of(2023, 1, 1),
           accountingPeriodTo = LocalDate.of(2022, 12, 31) // End date before start date
         )
 
-        // Execute
         val result = service.submitBTN(validPlrId, invalidRequest)
 
-        // Verify
-        whenReady(result.failed) { e =>
-          e mustBe RequestCouldNotBeProcessed
-        }
-        verify(mockOasRepository, never).findByPillar2Id(anyString(), any[LocalDate], any[LocalDate])
+        result shouldFailWith RequestCouldNotBeProcessed
       }
+
       "successfully submit a BTN when no existing submission for period" in {
-        when(mockBtnRepository.findByPillar2Id(anyString()))
+        when(mockOasRepository.findByPillar2Id(anyString(), any[LocalDate], any[LocalDate]))
           .thenReturn(Future.successful(Seq.empty))
+        when(mockBtnRepository.insert(anyString(), any[BTNRequest]()))
+          .thenReturn(Future.successful(new ObjectId()))
+        when(mockOasRepository.insert(any[BTNRequest](), anyString(), any[ObjectId]()))
+          .thenReturn(Future.successful(true))
+        when(mockOrgService.getOrganisation(anyString()))
+          .thenReturn(Future.successful(domesticOrganisation))
+
+        val result = service.submitBTN(validPlrId, validBTNRequest)
+
+        result.futureValue mustBe true
+        verify(mockBtnRepository).insert(validPlrId, validBTNRequest)
+        verify(mockOasRepository).insert(eqTo(validBTNRequest), eqTo(validPlrId), any[ObjectId]())
+      }
+
+      "successfully submit a BTN when there is a UKTR submission for the period but no BTN" in {
+        when(mockOasRepository.findByPillar2Id(anyString(), any[LocalDate], any[LocalDate]))
+          .thenReturn(Future.successful(Seq(uktrObligationsAndSubmissionsMongoSubmission)))
+        when(mockBtnRepository.insert(anyString(), any[BTNRequest]()))
+          .thenReturn(Future.successful(new ObjectId()))
+        when(mockOasRepository.insert(any[BTNRequest](), anyString(), any[ObjectId]()))
+          .thenReturn(Future.successful(true))
+        when(mockOrgService.getOrganisation(anyString()))
+          .thenReturn(Future.successful(domesticOrganisation))
+
+        val result = service.submitBTN(validPlrId, validBTNRequest)
+
+        result.futureValue mustBe true
+        verify(mockBtnRepository).insert(validPlrId, validBTNRequest)
+        verify(mockOasRepository).insert(eqTo(validBTNRequest), eqTo(validPlrId), any[ObjectId]())
+      }
+
+      "successfully submit a BTN when there is an older BTN submission for the period that is not the most recent submission" in {
+        when(mockOasRepository.findByPillar2Id(anyString(), any[LocalDate], any[LocalDate]))
+          .thenReturn(Future.successful(Seq(uktrObligationsAndSubmissionsMongoSubmission, olderBtnObligationsAndSubmissionsMongoSubmission)))
+        when(mockBtnRepository.insert(anyString(), any[BTNRequest]()))
+          .thenReturn(Future.successful(new ObjectId()))
+        when(mockOasRepository.insert(any[BTNRequest](), anyString(), any[ObjectId]()))
+          .thenReturn(Future.successful(true))
+        when(mockOrgService.getOrganisation(anyString()))
+          .thenReturn(Future.successful(domesticOrganisation))
+
+        val result = service.submitBTN(validPlrId, validBTNRequest)
+
+        result.futureValue mustBe true
+        verify(mockBtnRepository).insert(validPlrId, validBTNRequest)
+        verify(mockOasRepository).insert(eqTo(validBTNRequest), eqTo(validPlrId), any[ObjectId]())
+      }
+
+      "successfully submit a BTN when there is a BTN submission for a different period" in {
+        when(mockOasRepository.findByPillar2Id(anyString(), any[LocalDate], any[LocalDate]))
+          .thenReturn(Future.successful(Seq(differentPeriodBtnObligationsAndSubmissionsMongoSubmission)))
         when(mockBtnRepository.insert(anyString(), any[BTNRequest]()))
           .thenReturn(Future.successful(new ObjectId()))
         when(mockOasRepository.insert(any[BTNRequest](), anyString(), any[ObjectId]()))

--- a/test/uk/gov/hmrc/pillar2externalteststub/services/UKTRServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/services/UKTRServiceSpec.scala
@@ -25,6 +25,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.Json
 import uk.gov.hmrc.pillar2externalteststub.helpers.{ObligationsAndSubmissionsDataFixture, TestOrgDataFixture, UKTRDataFixture}
 import uk.gov.hmrc.pillar2externalteststub.models.common.BaseSubmission
+import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.TaxObligationAlreadyFulfilled
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.{InvalidReturn, InvalidTotalLiability, NoAssociatedDataFound}
 import uk.gov.hmrc.pillar2externalteststub.models.uktr._
 import uk.gov.hmrc.pillar2externalteststub.models.uktr.mongo.UKTRMongoSubmission
@@ -34,7 +35,6 @@ import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
-import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.TaxObligationAlreadyFulfilled
 
 class UKTRServiceSpec
     extends AnyFreeSpec
@@ -91,7 +91,7 @@ class UKTRServiceSpec
 
       "should fail with TaxObligationAlreadyFulfilled when submitting twice in a row" in {
         when(mockOrgService.getOrganisation(eqTo(validPlrId)))
-          .thenReturn(Future.successful(domesticOrganisation))
+          .thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.findByPillar2Id(eqTo(validPlrId)))
           .thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
 

--- a/test/uk/gov/hmrc/pillar2externalteststub/services/UKTRServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/services/UKTRServiceSpec.scala
@@ -23,7 +23,7 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.Json
-import uk.gov.hmrc.pillar2externalteststub.helpers.{TestOrgDataFixture, UKTRDataFixture}
+import uk.gov.hmrc.pillar2externalteststub.helpers.{ObligationsAndSubmissionsDataFixture, TestOrgDataFixture, UKTRDataFixture}
 import uk.gov.hmrc.pillar2externalteststub.models.common.BaseSubmission
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.{InvalidReturn, InvalidTotalLiability, NoAssociatedDataFound}
 import uk.gov.hmrc.pillar2externalteststub.models.uktr._
@@ -34,8 +34,15 @@ import java.time.Instant
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
+import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.TaxObligationAlreadyFulfilled
 
-class UKTRServiceSpec extends AnyFreeSpec with Matchers with MockitoSugar with UKTRDataFixture with TestOrgDataFixture {
+class UKTRServiceSpec
+    extends AnyFreeSpec
+    with Matchers
+    with MockitoSugar
+    with UKTRDataFixture
+    with TestOrgDataFixture
+    with ObligationsAndSubmissionsDataFixture {
 
   private val mockUKTRRepository = mock[UKTRSubmissionRepository]
   private val mockOASRepository  = mock[ObligationsAndSubmissionsRepository]
@@ -46,6 +53,8 @@ class UKTRServiceSpec extends AnyFreeSpec with Matchers with MockitoSugar with U
       "should successfully submit a liability return" in {
         when(mockOrgService.getOrganisation(eqTo(validPlrId)))
           .thenReturn(Future.successful(nonDomesticOrganisation))
+        when(mockUKTRRepository.findByPillar2Id(eqTo(validPlrId)))
+          .thenReturn(Future.successful(None))
         when(mockUKTRRepository.insert(any[UKTRLiabilityReturn], eqTo(validPlrId), any[Option[String]]))
           .thenReturn(Future.successful(new ObjectId()))
         when(mockOASRepository.insert(any[BaseSubmission], eqTo(validPlrId), any[ObjectId]))
@@ -64,6 +73,8 @@ class UKTRServiceSpec extends AnyFreeSpec with Matchers with MockitoSugar with U
       "should successfully submit a nil return" in {
         when(mockOrgService.getOrganisation(eqTo(validPlrId)))
           .thenReturn(Future.successful(domesticOrganisation))
+        when(mockUKTRRepository.findByPillar2Id(eqTo(validPlrId)))
+          .thenReturn(Future.successful(None))
         when(mockUKTRRepository.insert(any[UKTRNilReturn], eqTo(validPlrId), any[Option[String]]))
           .thenReturn(Future.successful(new ObjectId()))
         when(mockOASRepository.insert(any[BaseSubmission], eqTo(validPlrId), any[ObjectId]))
@@ -77,25 +88,28 @@ class UKTRServiceSpec extends AnyFreeSpec with Matchers with MockitoSugar with U
           case _ => fail("Expected NilSuccessResponse")
         }
       }
+
+      "should fail with TaxObligationAlreadyFulfilled when submitting twice in a row" in {
+        when(mockOrgService.getOrganisation(eqTo(validPlrId)))
+          .thenReturn(Future.successful(domesticOrganisation))
+        when(mockUKTRRepository.findByPillar2Id(eqTo(validPlrId)))
+          .thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
+
+        val result = service.submitUKTR(validPlrId, liabilitySubmission)
+        result shouldFailWith TaxObligationAlreadyFulfilled
+      }
     }
 
     "when amending a return" - {
       "should successfully amend a liability return" in {
-        val existingSubmission = UKTRMongoSubmission(
-          _id = new ObjectId(),
-          pillar2Id = validPlrId,
-          chargeReference = Some("existing-ref"),
-          data = liabilitySubmission,
-          submittedAt = Instant.now()
-        )
         when(mockOrgService.getOrganisation(eqTo(validPlrId)))
           .thenReturn(Future.successful(nonDomesticOrganisation))
 
         when(mockUKTRRepository.findByPillar2Id(eqTo(validPlrId)))
-          .thenReturn(Future.successful(Some(existingSubmission)))
+          .thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
 
         when(mockUKTRRepository.update(any[UKTRLiabilityReturn], eqTo(validPlrId)))
-          .thenReturn(Future.successful((new ObjectId(), Some("existing-ref"))))
+          .thenReturn(Future.successful((new ObjectId(), Some(chargeReference))))
         when(mockOASRepository.insert(any[BaseSubmission], eqTo(validPlrId), any[ObjectId]))
           .thenReturn(Future.successful(true))
 
@@ -104,7 +118,7 @@ class UKTRServiceSpec extends AnyFreeSpec with Matchers with MockitoSugar with U
           case LiabilitySuccessResponse(success) =>
             success.processingDate    should not be empty
             success.formBundleNumber  should not be empty
-            success.chargeReference shouldBe "existing-ref"
+            success.chargeReference shouldBe chargeReference
           case _ => fail("Expected LiabilitySuccessResponse")
         }
       }


### PR DESCRIPTION
This PR implements proper error handling for duplicate submissions of UKTR and BTN

### Changes

1. **UKTR Service Implementation**
   - Added validation to prevent duplicate UKTR submissions
   - Implemented 422:044 error response with "Tax Obligation already fulfilled" message

2. **BTN Service Implementation**
    - Added validation to check the latest submission via the obligations and submissions repository
    - If the latest submission is a BTN, we reject with 422:044 error
    - If the latest submission is not a BTN (e.g., a UKTR), we allow the submission
    - Fixed previous behavior that returned 422:004 instead of 422:044
