### PR TITLE
PIL-1910 : External test stubs to return latest 10 submissions for each obligations

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsController.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsController.scala
@@ -121,8 +121,17 @@ class ObligationsAndSubmissionsController @Inject() (
     val dueDate  = endDate.plusMonths(15)
     val canAmend = !LocalDate.now().isAfter(dueDate)
 
-    val p2TaxReturnSubmissions = submissions.filter(s => s.submissionType == UKTR || s.submissionType == BTN)
-    val girSubmissions         = submissions.filter(s => s.submissionType == GIR || s.submissionType == ORN)
+    val p2TaxReturnSubmissions = submissions
+      .filter(s => s.submissionType == UKTR || s.submissionType == BTN)
+      .sortBy(_.receivedDate)
+      .reverse
+      .take(10)
+
+    val girSubmissions = submissions
+      .filter(s => s.submissionType == GIR || s.submissionType == ORN)
+      .sortBy(_.receivedDate)
+      .reverse
+      .take(10)
 
     val domesticObligation = Seq(
       Obligation(


### PR DESCRIPTION
**Limit Obligations and submissions to the retrieve the latest 10 Submissions per Accounting Period**

This PR introduces logic to restrict the number of retrieved submissions per obligation type to the latest 10 submissions for each accounting period.

**Changes:**
**For UKTR obligations (including BTN and UKTR):**
Only the latest 10 submissions are returned.
Older submissions beyond the 10th (if any) are excluded.

**For GIR obligations (ORN):**
Only the latest 10 submissions are returned.
Older submissions beyond the 10th (if any) are excluded.

Submissions are sorted by submittedAt in descending order, ensuring the most recent ones are shown first.

Unit tests added to test this functionality


<img width="1167" alt="Screenshot 2025-04-14 at 13 37 49" src="https://github.com/user-attachments/assets/5c752480-c51f-4337-a413-37a97892084f" />

