### PR TITLE
PIL-1866: Missing Authorization to return 401

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/actions/AuthActionFilter.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/actions/AuthActionFilter.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.pillar2externalteststub.controllers.actions
 
-import play.api.mvc.Results.Forbidden
+import play.api.mvc.Results.Unauthorized
 import play.api.mvc.{ActionFilter, Request, Result}
 import uk.gov.hmrc.http.HeaderNames
 
@@ -28,7 +28,7 @@ class AuthActionFilter @Inject() ()(implicit ec: ExecutionContext) extends Actio
   override protected def filter[A](request: Request[A]): Future[Option[Result]] =
     request.headers.get(HeaderNames.authorisation) match {
       case Some(_) => Future.successful(None)
-      case _       => Future.successful(Some(Forbidden))
+      case _       => Future.successful(Some(Unauthorized))
     }
 
   override protected def executionContext: ExecutionContext = ec

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/SubscriptionControllerSpec.scala
@@ -44,7 +44,7 @@ class SubscriptionControllerSpec extends AnyFreeSpec with Matchers with GuiceOne
 
       "must return FORBIDDEN response when 'Authorization' header is missing" in {
         val result: Future[Result] = route(app, unauthorizedRequest("XEPLR0123456400")).value
-        status(result) shouldBe FORBIDDEN
+        status(result) shouldBe UNAUTHORIZED
       }
 
       "must return NOT_FOUND for plrReference 'XEPLR5555555554' with SUBSCRIPTION_NOT_FOUND" in {


### PR DESCRIPTION
Return 401 instead of 403. This code should never be reached as a missing Authorization would be stopped at the API layer, but kept here for added safety.