### PR TITLE
PIL-1978: Require HIP Headers

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/BTNController.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/BTNController.scala
@@ -45,7 +45,7 @@ class BTNController @Inject() (
         request.body
           .validate[BTNRequest]
           .fold(
-            _ => Future.failed(ETMPBadRequest),
+            _ => Future.failed(ETMPBadRequest()),
             btnRequest => handleSubmission(pillar2Id, btnRequest)
           )
       }

--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/ORNController.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/ORNController.scala
@@ -50,7 +50,7 @@ class ORNController @Inject() (
         request.body
           .validate[ORNRequest]
           .fold(
-            _ => Future.failed(ETMPBadRequest),
+            _ => Future.failed(ETMPBadRequest()),
             ornRequest => validateORN(pillar2Id, ornRequest)
           )
       }
@@ -62,7 +62,7 @@ class ORNController @Inject() (
         request.body
           .validate[ORNRequest]
           .fold(
-            _ => Future.failed(ETMPBadRequest),
+            _ => Future.failed(ETMPBadRequest()),
             ornRequest => validateORN(pillar2Id, ornRequest, isAmendment = true)
           )
       }
@@ -98,7 +98,7 @@ class ORNController @Inject() (
                 Future.failed(NoActiveSubscription)
               case e: DateTimeParseException =>
                 logger.error(s"Invalid date format: ${e.getMessage}")
-                Future.failed(ETMPBadRequest)
+                Future.failed(ETMPBadRequest())
             }
         }
     }

--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/StubErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/StubErrorHandler.scala
@@ -52,7 +52,7 @@ class StubErrorHandler extends HttpErrorHandler with Logging {
               TaxObligationAlreadyFulfilled | InvalidReturn | InvalidDTTElection | InvalidUTPRElection | InvalidTotalLiability |
               InvalidTotalLiabilityIIR | InvalidTotalLiabilityDTT | InvalidTotalLiabilityUTPR =>
             Results.UnprocessableEntity(Json.toJson(ETMPFailureResponse(ETMPDetailedError(e.code, e.message))))
-          case ETMPBadRequest          => Results.BadRequest(Json.toJson(ETMPErrorResponse(ETMPSimpleError(e))))
+          case ETMPBadRequest(_)       => Results.BadRequest(Json.toJson(ETMPErrorResponse(ETMPSimpleError(e))))
           case ETMPInternalServerError => Results.InternalServerError(Json.toJson(ETMPErrorResponse(ETMPSimpleError(e))))
         }
         logger.warn(s"Caught ETMPError. Returning ${ret.header.status} statuscode", exception)

--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/UKTRController.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/UKTRController.scala
@@ -44,7 +44,7 @@ class UKTRController @Inject() (
         request.body
           .validate[UKTRSubmission]
           .fold(
-            _ => Future.failed(ETMPBadRequest),
+            _ => Future.failed(ETMPBadRequest()),
             uktrRequest => uktrService.submitUKTR(pillar2Id, uktrRequest).map(response => Created(Json.toJson(response)(writes)))
           )
       }
@@ -56,7 +56,7 @@ class UKTRController @Inject() (
         request.body
           .validate[UKTRSubmission]
           .fold(
-            _ => Future.failed(ETMPBadRequest),
+            _ => Future.failed(ETMPBadRequest()),
             uktrRequest => uktrService.amendUKTR(pillar2Id, uktrRequest).map(response => Ok(Json.toJson(response)(writes)))
           )
       }

--- a/app/uk/gov/hmrc/pillar2externalteststub/helpers/Pillar2Helper.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/helpers/Pillar2Helper.scala
@@ -22,7 +22,13 @@ import scala.util.matching.Regex
 
 object Pillar2Helper {
   val pillar2Regex: Regex = "^[A-Z0-9]{1,15}$".r
-  val ServerErrorPlrId = "XEPLR5000000000"
+  val ServerErrorPlrId          = "XEPLR5000000000"
+  val correlationidHeader       = "correlationid"
+  val correlationidHeaderRegex  = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+  val xReceiptDateHeaderRegex   = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z"
+  val xReceiptDateHeader        = "X-Receipt-Date"
+  val xOriginatingSystemHeader  = "X-Originating-System"
+  val xTransmittingSystemHeader = "X-Transmitting-System"
 
   def nowZonedDateTime:           String = ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS).toString
   def generateFormBundleNumber(): String = f"${Random.nextLong(1000000000000L) % 1000000000000L}%012d"

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/error/ETMPError.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/error/ETMPError.scala
@@ -89,9 +89,9 @@ object ETMPError {
     override val message: String = "Invalid Total Liability UTPR"
   }
 
-  case object ETMPBadRequest extends ETMPError {
+  case class ETMPBadRequest(errorMessage: String = "Bad request") extends ETMPError {
     override val code:    String         = "400"
-    override val message: String         = "Bad request"
+    override val message: String         = errorMessage
     override val logID:   Option[String] = Some("C0000000000000000000000000000400")
   }
 

--- a/app/uk/gov/hmrc/pillar2externalteststub/services/UKTRService.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/services/UKTRService.scala
@@ -66,7 +66,7 @@ class UKTRService @Inject() (
         UKTRLiabilityReturn.uktrSubmissionValidator(pillar2Id)(organisationService, ec).map(_.asInstanceOf[ValidationRule[UKTRSubmission]])
       case _: UKTRNilReturn =>
         UKTRNilReturn.uktrNilReturnValidator(pillar2Id)(organisationService, ec).map(_.asInstanceOf[ValidationRule[UKTRSubmission]])
-      case _ => Future.failed(ETMPBadRequest)
+      case _ => Future.failed(ETMPBadRequest())
     }
 
   private def validateRequest(validator: ValidationRule[UKTRSubmission], request: UKTRSubmission): Future[Unit] =
@@ -114,12 +114,12 @@ class UKTRService @Inject() (
             oasRepository.insert(liability, pillar2Id, sub).map(_ => ())
           }
         }
-      case _ => Future.failed(ETMPBadRequest)
+      case _ => Future.failed(ETMPBadRequest())
     }
 
   private def createResponse(request: UKTRSubmission, existingChargeRef: Option[String] = None): UKTRResponse = request match {
     case _: UKTRLiabilityReturn => successfulUKTRResponse(existingChargeRef)
     case _: UKTRNilReturn       => successfulNilReturnResponse
-    case _ => throw ETMPBadRequest
+    case _ => throw ETMPBadRequest()
   }
 }

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/BTNISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/BTNISpec.scala
@@ -59,8 +59,8 @@ class BTNISpec
   private val baseUrl    = s"http://localhost:$port"
   override protected val repository: BTNSubmissionRepository             = app.injector.instanceOf[BTNSubmissionRepository]
   private val oasRepository:         ObligationsAndSubmissionsRepository = app.injector.instanceOf[ObligationsAndSubmissionsRepository]
-  implicit val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
-  implicit val hc: HeaderCarrier    = HeaderCarrier()
+  implicit val ec:                   ExecutionContext                    = app.injector.instanceOf[ExecutionContext]
+  implicit val hc:                   HeaderCarrier                       = HeaderCarrier()
 
   override def fakeApplication(): Application =
     GuiceApplicationBuilder()
@@ -72,20 +72,13 @@ class BTNISpec
       .overrides(inject.bind[OrganisationService].toInstance(mockOrgService))
       .build()
 
-  private def submitBTN(pillar2Id: String, request: BTNRequest): HttpResponse = {
-    val headers = Seq(
-      "Content-Type"  -> "application/json",
-      "Authorization" -> "Bearer token",
-      "X-Pillar2-Id"  -> pillar2Id
-    )
-
+  private def submitBTN(pillar2Id: String, request: BTNRequest): HttpResponse =
     httpClient
       .post(url"$baseUrl/RESTAdapter/plr/below-threshold-notification")
-      .transform(_.withHttpHeaders(headers: _*))
+      .transform(_.withHttpHeaders(hipHeaders :+ ("X-Pillar2-Id" -> pillar2Id): _*))
       .withBody(Json.toJson(request))
       .execute[HttpResponse]
       .futureValue
-  }
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -150,14 +143,9 @@ class BTNISpec
     }
 
     "handle invalid requests appropriately" in {
-      val headers = Seq(
-        "Content-Type"  -> "application/json",
-        "Authorization" -> "Bearer token"
-      )
-
       val responseWithoutId = httpClient
         .post(url"$baseUrl/RESTAdapter/plr/below-threshold-notification")
-        .transform(_.withHttpHeaders(headers: _*))
+        .transform(_.withHttpHeaders(hipHeaders: _*))
         .withBody(Json.toJson(validBTNRequest))
         .execute[HttpResponse]
         .futureValue

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/ObligationsAndSubmissionsISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/ObligationsAndSubmissionsISpec.scala
@@ -54,10 +54,10 @@ class ObligationsAndSubmissionsISpec
 
   private val httpClient = app.injector.instanceOf[HttpClientV2]
   private val baseUrl    = s"http://localhost:$port"
-  override protected val repository: ObligationsAndSubmissionsRepository = app.injector.instanceOf[ObligationsAndSubmissionsRepository]
-  private val organisationRepository: OrganisationRepository             = app.injector.instanceOf[OrganisationRepository]
-  implicit val ec:                   ExecutionContext                    = app.injector.instanceOf[ExecutionContext]
-  implicit val hc:                   HeaderCarrier                       = HeaderCarrier()
+  override protected val repository:  ObligationsAndSubmissionsRepository = app.injector.instanceOf[ObligationsAndSubmissionsRepository]
+  private val organisationRepository: OrganisationRepository              = app.injector.instanceOf[OrganisationRepository]
+  implicit val ec:                    ExecutionContext                    = app.injector.instanceOf[ExecutionContext]
+  implicit val hc:                    HeaderCarrier                       = HeaderCarrier()
 
   override def fakeApplication(): Application =
     GuiceApplicationBuilder()
@@ -70,25 +70,18 @@ class ObligationsAndSubmissionsISpec
 
   private def getObligationsAndSubmissions(
     pillar2Id: String,
-    fromDate: String = accountingPeriod.startDate.toString,
-    toDate:   String = accountingPeriod.endDate.toString
-  ): HttpResponse = {
-    val headers = Seq(
-      "Content-Type"  -> "application/json",
-      authHeader,
-      "X-Pillar2-Id"  -> pillar2Id
-    )
-
+    fromDate:  String = accountingPeriod.startDate.toString,
+    toDate:    String = accountingPeriod.endDate.toString
+  ): HttpResponse =
     httpClient
       .get(url"$baseUrl/RESTAdapter/plr/obligations-and-submissions?fromDate=$fromDate&toDate=$toDate")
-      .transform(_.withHttpHeaders(headers: _*))
+      .transform(_.withHttpHeaders(hipHeaders :+ ("X-Pillar2-Id" -> pillar2Id): _*))
       .execute[HttpResponse]
       .futureValue
-  }
 
   private def insertSubmission(
-    pillar2Id: String,
-    submissionType: SubmissionType,
+    pillar2Id:        String,
+    submissionType:   SubmissionType,
     accountingPeriod: AccountingPeriod
   ): ObligationsAndSubmissionsMongoSubmission = {
     val submission = ObligationsAndSubmissionsMongoSubmission(
@@ -132,23 +125,23 @@ class ObligationsAndSubmissionsISpec
       val response = getObligationsAndSubmissions(domesticOrganisation.pillar2Id)
       response.status shouldBe 200
 
-      val json = Json.parse(response.body)
+      val json                    = Json.parse(response.body)
       val accountingPeriodDetails = (json \ "success" \ "accountingPeriodDetails").as[Seq[JsValue]]
-      
+
       accountingPeriodDetails.size shouldBe 1
-      
+
       val obligations = (accountingPeriodDetails.head \ "obligations").as[Seq[JsValue]]
       obligations.size shouldBe 2
 
       // Verify obligations for domestic organisation
       (obligations.head \ "obligationType").as[String] shouldBe "UKTR"
-      (obligations(1)   \ "obligationType").as[String] shouldBe "GIR"
-      (obligations.head \ "status").as[String] shouldBe "Fulfilled"
-      (obligations(1)   \ "status").as[String] shouldBe "Open"
+      (obligations(1) \ "obligationType").as[String]   shouldBe "GIR"
+      (obligations.head \ "status").as[String]         shouldBe "Fulfilled"
+      (obligations(1) \ "status").as[String]           shouldBe "Open"
 
       // Verify submissions
       val submissions = (obligations.head \ "submissions").as[Seq[JsValue]]
-      submissions.size shouldBe 1
+      submissions.size                                 shouldBe 1
       (submissions.head \ "submissionType").as[String] shouldBe "UKTR_CREATE"
     }
 
@@ -163,27 +156,27 @@ class ObligationsAndSubmissionsISpec
       val response = getObligationsAndSubmissions(nonDomesticOrganisation.pillar2Id)
       response.status shouldBe 200
 
-      val json = Json.parse(response.body)
+      val json                    = Json.parse(response.body)
       val accountingPeriodDetails = (json \ "success" \ "accountingPeriodDetails").as[Seq[JsValue]]
-      
+
       accountingPeriodDetails.size shouldBe 1
-      
+
       val obligations = (accountingPeriodDetails.head \ "obligations").as[Seq[JsValue]]
       obligations.size shouldBe 2
-      
+
       // Verify first obligation is Pillar2TaxReturn with Open status
       (obligations.head \ "obligationType").as[String] shouldBe "UKTR"
-      (obligations.head \ "status").as[String] shouldBe "Open"
-      
+      (obligations.head \ "status").as[String]         shouldBe "Open"
+
       // Verify second obligation is GlobeInformationReturn with Fulfilled status
       (obligations(1) \ "obligationType").as[String] shouldBe "GIR"
-      (obligations(1) \ "status").as[String] shouldBe "Fulfilled"
-      
+      (obligations(1) \ "status").as[String]         shouldBe "Fulfilled"
+
       // Verify submissions in GIR obligation
       val submissions = (obligations(1) \ "submissions").as[Seq[JsValue]]
-      submissions.size shouldBe 1
+      submissions.size                                 shouldBe 1
       (submissions.head \ "submissionType").as[String] shouldBe "ORN_CREATE"
-      (submissions.head \ "country").as[String] shouldBe "US"
+      (submissions.head \ "country").as[String]        shouldBe "US"
     }
 
     "group submissions by accounting period" in {
@@ -192,70 +185,66 @@ class ObligationsAndSubmissionsISpec
         startDate = LocalDate.of(2023, 1, 1),
         endDate = LocalDate.of(2023, 12, 31)
       )
-      
+
       val period2 = AccountingPeriod(
         startDate = LocalDate.of(2024, 1, 1),
         endDate = LocalDate.of(2024, 12, 31)
       )
-      
+
       // Insert submissions for different accounting periods
       insertSubmission(nonDomesticOrganisation.pillar2Id, UKTR_CREATE, period1)
       insertSubmission(nonDomesticOrganisation.pillar2Id, ORN_CREATE, period1)
       insertSubmission(nonDomesticOrganisation.pillar2Id, BTN, period2)
-      
+
       val response = getObligationsAndSubmissions(
         nonDomesticOrganisation.pillar2Id,
-        fromDate = "2023-01-01", 
+        fromDate = "2023-01-01",
         toDate = "2024-12-31"
       )
-      
+
       response.status shouldBe 200
-      
-      val json = Json.parse(response.body)
+
+      val json                    = Json.parse(response.body)
       val accountingPeriodDetails = (json \ "success" \ "accountingPeriodDetails").as[Seq[JsValue]]
-      
+
       // Should have two accounting periods
       accountingPeriodDetails.size shouldBe 2
-      
+
       // Find period1 details
-      val period1Details = accountingPeriodDetails.find(period => 
-        (period \ "startDate").as[String] == "2023-01-01"
-      ).get
-      
+      val period1Details = accountingPeriodDetails.find(period => (period \ "startDate").as[String] == "2023-01-01").get
+
       // Find period2 details
-      val period2Details = accountingPeriodDetails.find(period => 
-        (period \ "startDate").as[String] == "2024-01-01"
-      ).get
-      
+      val period2Details = accountingPeriodDetails.find(period => (period \ "startDate").as[String] == "2024-01-01").get
+
       // Verify period1 has UKTR and ORN submissions
       val period1Obligations = (period1Details \ "obligations").as[Seq[JsValue]]
-      val period1P2Status = (period1Obligations.head \ "status").as[String]
-      val period1GIRStatus = (period1Obligations(1) \ "status").as[String]
-      
-      period1P2Status shouldBe "Fulfilled"
+      val period1P2Status    = (period1Obligations.head \ "status").as[String]
+      val period1GIRStatus   = (period1Obligations(1) \ "status").as[String]
+
+      period1P2Status  shouldBe "Fulfilled"
       period1GIRStatus shouldBe "Fulfilled"
-      
+
       // Verify period2 has BTN submission
       val period2Obligations = (period2Details \ "obligations").as[Seq[JsValue]]
-      val period2P2Status = (period2Obligations.head \ "status").as[String]
-      
+      val period2P2Status    = (period2Obligations.head \ "status").as[String]
+
       period2P2Status shouldBe "Fulfilled"
     }
 
     "use organisation's default accounting period when no submissions exist" in {
       val response = getObligationsAndSubmissions(domesticOrganisation.pillar2Id)
       response.status shouldBe 200
-      
-      val json = Json.parse(response.body)
+
+      val json                    = Json.parse(response.body)
       val accountingPeriodDetails = (json \ "success" \ "accountingPeriodDetails").as[Seq[JsValue]]
-      
+
       // Should have only one accounting period
       accountingPeriodDetails.size shouldBe 1
-      
+
       // Period should match org's default period
       (accountingPeriodDetails.head \ "startDate").as[String] shouldBe domesticOrganisation.organisation.accountingPeriod.startDate.toString
-      (accountingPeriodDetails.head \ "endDate").as[String] shouldBe domesticOrganisation.organisation.accountingPeriod.endDate.toString
-      
+      (accountingPeriodDetails.head \ "endDate").as[String]   shouldBe domesticOrganisation.organisation.accountingPeriod.endDate.toString
+
       // Obligation should be Open
       val obligations = (accountingPeriodDetails.head \ "obligations").as[Seq[JsValue]]
       (obligations.head \ "status").as[String] shouldBe "Open"
@@ -268,7 +257,7 @@ class ObligationsAndSubmissionsISpec
         BTN,
         AccountingPeriod(accountingPeriod.startDate, accountingPeriod.endDate)
       )
-      
+
       val response = getObligationsAndSubmissions(nonDomesticOrganisation.pillar2Id)
       response.status shouldBe 200
 
@@ -285,10 +274,10 @@ class ObligationsAndSubmissionsISpec
     "handle error cases correctly" in {
       // Test organisation not found
       val nonExistentPlrIdResponse = getObligationsAndSubmissions("NONEXISTENT")
-      val nonExistentPlrIdJson = Json.parse(nonExistentPlrIdResponse.body)
+      val nonExistentPlrIdJson     = Json.parse(nonExistentPlrIdResponse.body)
       (nonExistentPlrIdJson \ "errors" \ "text").as[String] shouldBe "No data found"
-      nonExistentPlrIdResponse.status shouldBe 422
-      
+      nonExistentPlrIdResponse.status                       shouldBe 422
+
       // Test invalid date format
       val invalidDateResponse = getObligationsAndSubmissions(
         domesticOrganisation.pillar2Id,
@@ -296,7 +285,7 @@ class ObligationsAndSubmissionsISpec
       )
       val invalidDateJson = Json.parse(invalidDateResponse.body)
       (invalidDateJson \ "errors" \ "text").as[String] shouldBe "Request could not be processed"
-      invalidDateResponse.status shouldBe 422
+      invalidDateResponse.status                       shouldBe 422
       // Test fromDate after toDate
       val invalidDateRangeResponse = getObligationsAndSubmissions(
         domesticOrganisation.pillar2Id,
@@ -314,28 +303,27 @@ class ObligationsAndSubmissionsISpec
         startDate = LocalDate.now().minusYears(3),
         endDate = LocalDate.now().minusYears(2).minusDays(1)
       )
-      
+
       insertSubmission(
         domesticOrganisation.pillar2Id,
         UKTR_CREATE,
         pastAccountingPeriod
       )
-      
+
       val response = getObligationsAndSubmissions(
         domesticOrganisation.pillar2Id,
         fromDate = pastAccountingPeriod.startDate.toString,
         toDate = pastAccountingPeriod.endDate.toString
       )
-      
+
       response.status shouldBe 200
-      
-      val json = Json.parse(response.body)
+
+      val json                    = Json.parse(response.body)
       val accountingPeriodDetails = (json \ "success" \ "accountingPeriodDetails").as[Seq[JsValue]]
-      val obligations = (accountingPeriodDetails.head \ "obligations").as[Seq[JsValue]]
-      
+      val obligations             = (accountingPeriodDetails.head \ "obligations").as[Seq[JsValue]]
+
       // canAmend should be false for past due date
       (obligations.head \ "canAmend").as[Boolean] shouldBe false
     }
   }
-} 
-
+}

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/UKTRSubmissionISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/UKTRSubmissionISpec.scala
@@ -108,7 +108,7 @@ class UKTRSubmissionISpec
     httpClient
       .post(url"$baseUrl/RESTAdapter/plr/uk-tax-return")
       .withBody(Json.toJson(updatedSubmission))
-      .setHeader("Authorization" -> authToken, "X-Pillar2-Id" -> pillar2Id)
+      .setHeader(hipHeaders :+ ("X-Pillar2-Id" -> pillar2Id): _*)
       .execute[HttpResponse]
       .futureValue
   }
@@ -118,7 +118,7 @@ class UKTRSubmissionISpec
     httpClient
       .post(url"$baseUrl/RESTAdapter/plr/uk-tax-return")
       .withBody(Json.toJson(updatedSubmission))
-      .setHeader("X-Pillar2-Id" -> pillar2Id)
+      .setHeader(hipHeaders.tail :+ ("X-Pillar2-Id" -> pillar2Id): _*)
       .execute[HttpResponse]
       .futureValue
   }
@@ -127,7 +127,7 @@ class UKTRSubmissionISpec
     httpClient
       .post(url"$baseUrl/RESTAdapter/plr/uk-tax-return")
       .withBody(payload)
-      .setHeader("Authorization" -> authToken, "X-Pillar2-Id" -> pillar2Id)
+      .setHeader(hipHeaders :+ ("X-Pillar2-Id" -> pillar2Id): _*)
       .execute[HttpResponse]
       .futureValue
 
@@ -136,7 +136,7 @@ class UKTRSubmissionISpec
     httpClient
       .put(url"$baseUrl/RESTAdapter/plr/uk-tax-return")
       .withBody(Json.toJson(updatedSubmission))
-      .setHeader("Authorization" -> authToken, "X-Pillar2-Id" -> pillar2Id)
+      .setHeader(hipHeaders :+ ("X-Pillar2-Id" -> pillar2Id): _*)
       .execute[HttpResponse]
       .futureValue
   }
@@ -146,7 +146,7 @@ class UKTRSubmissionISpec
     httpClient
       .put(url"$baseUrl/RESTAdapter/plr/uk-tax-return")
       .withBody(Json.toJson(updatedSubmission))
-      .setHeader("X-Pillar2-Id" -> pillar2Id)
+      .setHeader(hipHeaders.tail :+ ("X-Pillar2-Id" -> pillar2Id): _*)
       .execute[HttpResponse]
       .futureValue
   }
@@ -155,7 +155,7 @@ class UKTRSubmissionISpec
     httpClient
       .post(url"$baseUrl/RESTAdapter/plr/uk-tax-return")
       .withBody(correctNilReturnJson)
-      .setHeader("Authorization" -> authToken, "X-Pillar2-Id" -> pillar2Id)
+      .setHeader(hipHeaders :+ ("X-Pillar2-Id" -> pillar2Id): _*)
       .execute[HttpResponse]
       .futureValue
 
@@ -163,7 +163,7 @@ class UKTRSubmissionISpec
     httpClient
       .put(url"$baseUrl/RESTAdapter/plr/uk-tax-return")
       .withBody(correctNilReturnJson)
-      .setHeader("Authorization" -> authToken, "X-Pillar2-Id" -> pillar2Id)
+      .setHeader(hipHeaders :+ ("X-Pillar2-Id" -> pillar2Id): _*)
       .execute[HttpResponse]
       .futureValue
 
@@ -293,6 +293,7 @@ class UKTRSubmissionISpec
         val response = httpClient
           .post(url"$baseUrl/RESTAdapter/plr/uk-tax-return")
           .withBody(Json.toJson(liabilitySubmission))
+          .setHeader(hipHeaders.tail: _*)
           .setHeader("Authorization" -> authToken)
           .execute[HttpResponse]
           .futureValue

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/BTNControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/BTNControllerSpec.scala
@@ -56,7 +56,7 @@ class BTNControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSui
 
       "should return IdMissingOrInvalid when X-Pillar2-Id header is missing" in {
         val request = FakeRequest(POST, "/RESTAdapter/plr/below-threshold-notification")
-          .withHeaders("Content-Type" -> "application/json", authHeader)
+          .withHeaders(hipHeaders: _*)
           .withBody(validBTNRequestBody)
 
         val result = route(app, request).get
@@ -71,7 +71,7 @@ class BTNControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSui
 
       "should return ETMPBadRequest when request body is invalid JSON" in {
         val result = route(app, createRequest(validPlrId, Json.obj("invalid" -> "request"))).get
-        result shouldFailWith ETMPBadRequest
+        result shouldFailWith ETMPBadRequest()
       }
 
       "should return ETMPInternalServerError when specific Pillar2 ID indicates server error" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/ORNControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/ORNControllerSpec.scala
@@ -60,7 +60,7 @@ class ORNControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSui
 
       "should return IdMissingOrInvalid when X-Pillar2-Id header is missing" in {
         val request = FakeRequest(POST, "/RESTAdapter/plr/overseas-return-notification")
-          .withHeaders("Content-Type" -> "application/json", authHeader)
+          .withHeaders(hipHeaders: _*)
           .withBody(validRequestBody)
 
         val result = route(app, request).get
@@ -83,7 +83,7 @@ class ORNControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSui
 
       "should return ETMPBadRequest when request body is invalid JSON" in {
         val result = route(app, createSubmitRequest(validPlrId, Json.obj("invalid" -> "request"))).get
-        result shouldFailWith ETMPBadRequest
+        result shouldFailWith ETMPBadRequest()
       }
 
       "should return ETMPInternalServerError when specific Pillar2 ID indicates server error" in {
@@ -115,7 +115,7 @@ class ORNControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSui
 
       "should return ETMPBadRequest when amendment request body is invalid JSON" in {
         val result = route(app, createAmendRequest(validPlrId, Json.obj("invalid" -> "request"))).get
-        result shouldFailWith ETMPBadRequest
+        result shouldFailWith ETMPBadRequest()
       }
     }
 
@@ -178,7 +178,7 @@ class ORNControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSui
         val toDate   = "2024-12-31"
 
         val result = route(app, getORNRequest(validPlrId, fromDate, toDate)).get
-        result shouldFailWith ETMPBadRequest
+        result shouldFailWith ETMPBadRequest()
       }
     }
   }

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsControllerSpec.scala
@@ -95,7 +95,7 @@ class ObligationsAndSubmissionsControllerSpec
     toDate:   String = accountingPeriod.endDate.toString
   ) =
     FakeRequest(GET, routes.ObligationsAndSubmissionsController.getObligationsAndSubmissions(fromDate, toDate).url)
-      .withHeaders(authHeader, "X-Pillar2-Id" -> plrId)
+      .withHeaders(hipHeaders :+ ("X-Pillar2-Id" -> plrId): _*)
 
   "Obligations and Submissions" - {
     "when requesting Obligations and Submissions" - {

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/StubErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/StubErrorHandlerSpec.scala
@@ -197,13 +197,24 @@ class StubErrorHandlerSpec extends AnyWordSpec with Matchers {
       (json \ "errors" \ "text").as[String] shouldBe "Invalid Total Liability UTPR"
     }
 
-    "handle ETMPBadRequest error" in {
-      val result = errorHandler.onServerError(dummyRequest, ETMPBadRequest)
-      status(result) shouldBe BAD_REQUEST
-      val json = contentAsJson(result)
-      (json \ "error" \ "code").as[String]    shouldBe "400"
-      (json \ "error" \ "message").as[String] shouldBe "Bad request"
-      (json \ "error" \ "logID").as[String]   shouldBe "C0000000000000000000000000000400"
+    "handle ETMPBadRequest error" should {
+      "static message" in {
+        val result = errorHandler.onServerError(dummyRequest, ETMPBadRequest())
+        status(result) shouldBe BAD_REQUEST
+        val json = contentAsJson(result)
+        (json \ "error" \ "code").as[String]    shouldBe "400"
+        (json \ "error" \ "message").as[String] shouldBe "Bad request"
+        (json \ "error" \ "logID").as[String]   shouldBe "C0000000000000000000000000000400"
+      }
+
+      "dynamic message" in {
+        val result = errorHandler.onServerError(dummyRequest, ETMPBadRequest("Missing Header"))
+        status(result) shouldBe BAD_REQUEST
+        val json = contentAsJson(result)
+        (json \ "error" \ "code").as[String]    shouldBe "400"
+        (json \ "error" \ "message").as[String] shouldBe "Missing Header"
+        (json \ "error" \ "logID").as[String]   shouldBe "C0000000000000000000000000000400"
+      }
     }
 
     "handle ETMPInternalServerError error" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/SubscriptionControllerSpec.scala
@@ -24,19 +24,20 @@ import play.api.libs.json.Json
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import uk.gov.hmrc.http.HeaderNames
+import uk.gov.hmrc.pillar2externalteststub.helpers.Pillar2DataFixture
 import uk.gov.hmrc.pillar2externalteststub.models.subscription._
 
 import scala.concurrent.Future
 
-class SubscriptionControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSuite with OptionValues {
+class SubscriptionControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSuite with OptionValues with Pillar2DataFixture {
 
   private def authorizedRequest(plrReference: String) =
     FakeRequest(GET, routes.SubscriptionController.retrieveSubscription(plrReference).url)
-      .withHeaders(HeaderNames.authorisation -> "Bearer valid_token")
+      .withHeaders(hipHeaders: _*)
 
   private def unauthorizedRequest(plrReference: String) =
     FakeRequest(GET, routes.SubscriptionController.retrieveSubscription(plrReference).url)
+      .withHeaders(hipHeaders.tail: _*)
 
   "SubscriptionController" - {
 

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/UKTRControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/UKTRControllerSpec.scala
@@ -72,7 +72,7 @@ class UKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSu
 
       "should return IdMissingOrInvalid when X-Pillar2-Id header is missing" in {
         val request = FakeRequest(POST, "/RESTAdapter/plr/uk-tax-return")
-          .withHeaders("Content-Type" -> "application/json", authHeader)
+          .withHeaders(hipHeaders: _*)
           .withBody(validRequestBody)
 
         val result = route(app, request).get
@@ -87,7 +87,7 @@ class UKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSu
 
       "should return ETMPBadRequest when request body is invalid JSON" in {
         val result = route(app, createRequest(validPlrId, Json.obj("invalid" -> "request"))).get
-        result shouldFailWith ETMPBadRequest
+        result shouldFailWith ETMPBadRequest()
       }
 
       "should return ETMPInternalServerError when specific Pillar2 ID indicates server error" in {
@@ -122,7 +122,7 @@ class UKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSu
 
       "should return ETMPBadRequest when amendment request body is invalid JSON" in {
         val result = route(app, createAmendRequest(validPlrId, Json.obj("invalid" -> "request"))).get
-        result shouldFailWith ETMPBadRequest
+        result shouldFailWith ETMPBadRequest()
       }
     }
   }
@@ -131,17 +131,17 @@ class UKTRControllerSpec extends AnyFreeSpec with Matchers with GuiceOneAppPerSu
     val method = if (isAmend) PUT else POST
     val url    = if (isAmend) "/RESTAdapter/plr/uk-tax-return" else "/RESTAdapter/plr/uk-tax-return"
     FakeRequest(method, url)
-      .withHeaders("Content-Type" -> "application/json", "X-Pillar2-Id" -> pillar2Id, authHeader)
+      .withHeaders(hipHeaders :+ ("X-Pillar2-Id" -> pillar2Id): _*)
       .withBody(Json.toJson(body))
   }
 
   private def createRequest(pillar2Id: String, body: JsValue) =
     FakeRequest(POST, "/RESTAdapter/plr/uk-tax-return")
-      .withHeaders("Content-Type" -> "application/json", "X-Pillar2-Id" -> pillar2Id, authHeader)
+      .withHeaders(hipHeaders :+ ("X-Pillar2-Id" -> pillar2Id): _*)
       .withBody(body)
 
   private def createAmendRequest(pillar2Id: String, body: JsValue) =
     FakeRequest(PUT, "/RESTAdapter/plr/uk-tax-return")
-      .withHeaders("Content-Type" -> "application/json", "X-Pillar2-Id" -> pillar2Id, authHeader)
+      .withHeaders(hipHeaders :+ ("X-Pillar2-Id" -> pillar2Id): _*)
       .withBody(body)
 }

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/actions/AuthActionFilterSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/actions/AuthActionFilterSpec.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.controllers.actions
+
+import org.scalatest.Assertion
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.mvc.Results
+import play.api.test.FakeRequest
+import uk.gov.hmrc.pillar2externalteststub.helpers.Pillar2DataFixture
+import uk.gov.hmrc.pillar2externalteststub.helpers.Pillar2Helper._
+import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.ETMPBadRequest
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class AuthActionFilterSpec extends AnyWordSpec with Matchers with ScalaFutures with Pillar2DataFixture {
+
+  val authActionFilter = new AuthActionFilter()
+
+  "AuthActionFilter" should {
+    "allow request with valid headers" in {
+      val request = FakeRequest().withHeaders(hipHeaders: _*)
+      authActionFilter.filter(request).futureValue shouldBe None
+    }
+
+    "return Unauthorized when Authorization header is missing" in {
+      val request = FakeRequest().withHeaders(hipHeaders.tail: _*)
+      authActionFilter.filter(request).futureValue shouldBe Some(Results.Unauthorized)
+    }
+
+    "throw ETMPBadRequest" when {
+      def testHeader(header: String, invalidValue: String = ""): Assertion = {
+        val headers = {
+          val filteredHeaders = hipHeaders.filterNot(_._1 == header)
+          if (invalidValue.isEmpty) filteredHeaders else filteredHeaders :+ (header -> invalidValue)
+        }
+        val exception = intercept[ETMPBadRequest](authActionFilter.filter(FakeRequest().withHeaders(headers: _*)).futureValue)
+        exception.message shouldEqual s"Header is missing or invalid: $header"
+      }
+
+      "correlationid is missing" in {
+        testHeader(correlationidHeader)
+      }
+
+      "correlationid is invalid" in {
+        testHeader(correlationidHeader, "invalid-correlation-id")
+      }
+
+      "X-Receipt-Date header is missing" in {
+        testHeader(xReceiptDateHeader)
+      }
+
+      "X-Receipt-Date header is invalid" in {
+        testHeader(xReceiptDateHeader, "invalid-date")
+      }
+
+      "X-Originating-System header is missing" in {
+        testHeader(xOriginatingSystemHeader)
+      }
+
+      "X-Originating-System header is invalid" in {
+        testHeader(xOriginatingSystemHeader, "INVALID")
+      }
+
+      "X-Transmitting-System header is missing" in {
+        testHeader(xTransmittingSystemHeader)
+      }
+
+      "X-Transmitting-System header is invalid" in {
+        testHeader(xTransmittingSystemHeader, "INVALID")
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/actions/AuthActionFilterSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/actions/AuthActionFilterSpec.scala
@@ -49,8 +49,7 @@ class AuthActionFilterSpec extends AnyWordSpec with Matchers with ScalaFutures w
           val filteredHeaders = hipHeaders.filterNot(_._1 == header)
           if (invalidValue.isEmpty) filteredHeaders else filteredHeaders :+ (header -> invalidValue)
         }
-        val exception = intercept[ETMPBadRequest](authActionFilter.filter(FakeRequest().withHeaders(headers: _*)).futureValue)
-        exception.message shouldEqual s"Header is missing or invalid: $header"
+        authActionFilter.filter(FakeRequest().withHeaders(headers: _*)) shouldFailWith ETMPBadRequest(s"Header is missing or invalid: $header")
       }
 
       "correlationid is missing" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/BTNDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/BTNDataFixture.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.pillar2externalteststub.helpers
 
 import org.bson.types.ObjectId
-import play.api.http.HeaderNames
 import play.api.libs.json.{JsValue, Json}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.POST
@@ -45,7 +44,7 @@ trait BTNDataFixture extends Pillar2DataFixture {
 
   def createRequest(plrId: String, body: JsValue): FakeRequest[JsValue] =
     FakeRequest(POST, "/RESTAdapter/plr/below-threshold-notification")
-      .withHeaders(HeaderNames.CONTENT_TYPE -> "application/json", authHeader, "X-Pillar2-Id" -> plrId)
+      .withHeaders(hipHeaders :+ ("X-Pillar2-Id" -> plrId): _*)
       .withBody(body)
 
   def createRequestWithBody(plrId: String, request: BTNRequest): FakeRequest[JsValue] =

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/ORNDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/ORNDataFixture.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.pillar2externalteststub.helpers
 
 import org.bson.types.ObjectId
-import play.api.http.HeaderNames
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
@@ -56,12 +55,12 @@ trait ORNDataFixture extends Pillar2DataFixture {
 
   def createSubmitRequest(plrId: String, body: JsValue): FakeRequest[JsValue] =
     FakeRequest(POST, "/RESTAdapter/plr/overseas-return-notification")
-      .withHeaders(HeaderNames.CONTENT_TYPE -> "application/json", authHeader, "X-Pillar2-Id" -> plrId)
+      .withHeaders(hipHeaders :+ ("X-Pillar2-Id" -> plrId): _*)
       .withBody(body)
 
   def createAmendRequest(plrId: String, body: JsValue): FakeRequest[JsValue] =
     FakeRequest(PUT, "/RESTAdapter/plr/overseas-return-notification")
-      .withHeaders(HeaderNames.CONTENT_TYPE -> "application/json", authHeader, "X-Pillar2-Id" -> plrId)
+      .withHeaders(hipHeaders :+ ("X-Pillar2-Id" -> plrId): _*)
       .withBody(body)
 
   def createRequestWithBody(plrId: String, request: ORNRequest, isAmend: Boolean = false): FakeRequest[JsValue] =
@@ -70,5 +69,5 @@ trait ORNDataFixture extends Pillar2DataFixture {
 
   def getORNRequest(plrId: String, fromDate: String, toDate: String): FakeRequest[AnyContentAsEmpty.type] =
     FakeRequest(GET, s"/RESTAdapter/plr/overseas-return-notification?accountingPeriodFrom=$fromDate&accountingPeriodTo=$toDate")
-      .withHeaders(authHeader, "X-Pillar2-Id" -> plrId)
+      .withHeaders(hipHeaders :+ ("X-Pillar2-Id" -> plrId): _*)
 }

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/Pillar2DataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/Pillar2DataFixture.scala
@@ -19,9 +19,11 @@ package uk.gov.hmrc.pillar2externalteststub.helpers
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers._
 import uk.gov.hmrc.http.HeaderNames
+import uk.gov.hmrc.pillar2externalteststub.helpers.Pillar2Helper._
 import uk.gov.hmrc.pillar2externalteststub.models.organisation.AccountingPeriod
 
 import java.time.LocalDate
+import java.util.UUID
 import scala.concurrent.Await
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -36,6 +38,13 @@ trait Pillar2DataFixture {
   }
 
   val authHeader: (String, String) = HeaderNames.authorisation -> "Bearer valid_token"
+  val hipHeaders: Seq[(String, String)] = Seq(
+    authHeader,
+    correlationidHeader       -> UUID.randomUUID().toString,
+    xReceiptDateHeader        -> nowZonedDateTime,
+    xTransmittingSystemHeader -> "HIP",
+    xOriginatingSystemHeader  -> "MDTP"
+  )
 
   val validPlrId       = "XMPLR0000000000"
   val chargeReference  = "XM000000000000"


### PR DESCRIPTION
Adds checks for the following 4 `HIP` headers, throwing a dynamic `400` if missing or invalid:
- `correlationid` (of pattern "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
- `X-Receipt-Date` (of pattern "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z")
- `X-Originating-System` (to equal **MDTP**)
- `X-Transmitting-System` (to equal **HIP**)

