### PR TITLE
PIL-2044: O&S - Fix canAmend and dueDate

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsController.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsController.scala
@@ -80,6 +80,7 @@ class ObligationsAndSubmissionsController @Inject() (
         createAccountingPeriodDetails(
           testOrg.organisation.accountingPeriod.startDate,
           testOrg.organisation.accountingPeriod.endDate,
+          testOrg.organisation.orgDetails.registrationDate,
           Seq.empty
         )
       )
@@ -89,6 +90,7 @@ class ObligationsAndSubmissionsController @Inject() (
         createAccountingPeriodDetails(
           accountingPeriod.startDate,
           accountingPeriod.endDate,
+          testOrg.organisation.orgDetails.registrationDate,
           submissions.map(toSubmission)
         )
       }.toSeq
@@ -116,10 +118,11 @@ class ObligationsAndSubmissionsController @Inject() (
   private def createAccountingPeriodDetails(
     startDate:   LocalDate,
     endDate:     LocalDate,
+    regDate:     LocalDate,
     submissions: Seq[Submission]
   ): AccountingPeriodDetails = {
-    val dueDate  = endDate.plusMonths(15)
-    val canAmend = !LocalDate.now().isAfter(dueDate)
+    val dueDate  = regDate.plusMonths(18)
+    val canAmend = !LocalDate.now().isAfter(dueDate.plusYears(1))
 
     val p2TaxReturnSubmissions = submissions
       .filter(s =>

--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsController.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsController.scala
@@ -122,7 +122,7 @@ class ObligationsAndSubmissionsController @Inject() (
     submissions: Seq[Submission]
   ): AccountingPeriodDetails = {
     val dueDate  = regDate.plusMonths(18)
-    val canAmend = !LocalDate.now().isAfter(dueDate.plusYears(1))
+    val canAmend = LocalDate.now().isBefore(dueDate.plusYears(1))
 
     val p2TaxReturnSubmissions = submissions
       .filter(s =>

--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsController.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsController.scala
@@ -20,7 +20,7 @@ import play.api.Logging
 import play.api.libs.json.Json
 import play.api.mvc._
 import uk.gov.hmrc.pillar2externalteststub.controllers.actions.AuthActionFilter
-import uk.gov.hmrc.pillar2externalteststub.helpers.Pillar2Helper.nowZonedDateTime
+import uk.gov.hmrc.pillar2externalteststub.helpers.Pillar2Helper._
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.{NoDataFound, RequestCouldNotBeProcessed}
 import uk.gov.hmrc.pillar2externalteststub.models.error.OrganisationNotFound
 import uk.gov.hmrc.pillar2externalteststub.models.obligationsAndSubmissions.ObligationStatus.{Fulfilled, Open}
@@ -121,8 +121,8 @@ class ObligationsAndSubmissionsController @Inject() (
     regDate:     LocalDate,
     submissions: Seq[Submission]
   ): AccountingPeriodDetails = {
-    val dueDate  = regDate.plusMonths(18)
-    val canAmend = LocalDate.now().isBefore(dueDate.plusYears(1))
+    val dueDate  = regDate.plusMonths(FIRST_AP_DUE_DATE_FROM_REGISTRATION_MONTHS)
+    val canAmend = LocalDate.now().isBefore(dueDate.plusMonths(AMENDMENT_WINDOW_MONTHS))
 
     val p2TaxReturnSubmissions = submissions
       .filter(s =>
@@ -132,7 +132,7 @@ class ObligationsAndSubmissionsController @Inject() (
       )
       .sortBy(_.receivedDate)
       .reverse
-      .take(10)
+      .take(MAX_NO_SUBMISSIONS)
 
     val girSubmissions = submissions
       .filter(s =>
@@ -142,7 +142,7 @@ class ObligationsAndSubmissionsController @Inject() (
       )
       .sortBy(_.receivedDate)
       .reverse
-      .take(10)
+      .take(MAX_NO_SUBMISSIONS)
 
     val domesticObligation = Seq(
       Obligation(

--- a/app/uk/gov/hmrc/pillar2externalteststub/helpers/Pillar2Helper.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/helpers/Pillar2Helper.scala
@@ -22,7 +22,6 @@ import scala.util.matching.Regex
 
 object Pillar2Helper {
   val pillar2Regex: Regex = "^[A-Z0-9]{1,15}$".r
-  
   val ServerErrorPlrId          = "XEPLR5000000000"
   val correlationidHeader       = "correlationid"
   val correlationidHeaderRegex  = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"

--- a/app/uk/gov/hmrc/pillar2externalteststub/helpers/Pillar2Helper.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/helpers/Pillar2Helper.scala
@@ -23,6 +23,9 @@ import scala.util.matching.Regex
 object Pillar2Helper {
   val pillar2Regex: Regex = "^[A-Z0-9]{1,15}$".r
   val ServerErrorPlrId = "XEPLR5000000000"
+  val MAX_NO_SUBMISSIONS:                         Int  = 10
+  val AMENDMENT_WINDOW_MONTHS:                    Long = 12
+  val FIRST_AP_DUE_DATE_FROM_REGISTRATION_MONTHS: Long = 18
 
   def nowZonedDateTime:           String = ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS).toString
   def generateFormBundleNumber(): String = f"${Random.nextLong(1000000000000L) % 1000000000000L}%012d"

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/ObligationsAndSubmissionsISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/ObligationsAndSubmissionsISpec.scala
@@ -307,35 +307,6 @@ class ObligationsAndSubmissionsISpec
       val invalidDateRangeJson = Json.parse(invalidDateRangeResponse.body)
       (invalidDateRangeJson \ "errors" \ "text").as[String] shouldBe "Request could not be processed"
     }
-
-    "set canAmend flag correctly based on due date" in {
-      // Create accounting period with past due date
-      val pastAccountingPeriod = AccountingPeriod(
-        startDate = LocalDate.now().minusYears(3),
-        endDate = LocalDate.now().minusYears(2).minusDays(1)
-      )
-      
-      insertSubmission(
-        domesticOrganisation.pillar2Id,
-        UKTR_CREATE,
-        pastAccountingPeriod
-      )
-      
-      val response = getObligationsAndSubmissions(
-        domesticOrganisation.pillar2Id,
-        fromDate = pastAccountingPeriod.startDate.toString,
-        toDate = pastAccountingPeriod.endDate.toString
-      )
-      
-      response.status shouldBe 200
-      
-      val json = Json.parse(response.body)
-      val accountingPeriodDetails = (json \ "success" \ "accountingPeriodDetails").as[Seq[JsValue]]
-      val obligations = (accountingPeriodDetails.head \ "obligations").as[Seq[JsValue]]
-      
-      // canAmend should be false for past due date
-      (obligations.head \ "canAmend").as[Boolean] shouldBe false
-    }
   }
 } 
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,7 +9,9 @@ object AppDependencies {
     "org.typelevel"     %% "cats-core"                 % "2.13.0",
     "uk.gov.hmrc"       %% "bootstrap-backend-play-30" % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"        % hmrcMongoVersion,
-    "com.beachape"      %% "enumeratum-play-json"      % "1.8.2"
+    "com.beachape"      %% "enumeratum-play-json"      % "1.8.2",
+    "dev.optics"        %% "monocle-core"              % "3.3.0",
+    "dev.optics"        %% "monocle-macro"             % "3.3.0"
   )
 
   val test: Seq[ModuleID] = Seq(

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsControllerSpec.scala
@@ -202,7 +202,7 @@ class ObligationsAndSubmissionsControllerSpec
         submissions.size mustBe 1
         submissions.head.submissionType mustBe SubmissionType.GIR
       }
-      
+
       "set canAmend flag correctly based on due date" - {
         val registrationDatePath = GenLens[TestOrganisationWithId](_.organisation)
           .andThen(GenLens[TestOrganisation](_.orgDetails))

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsControllerSpec.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.pillar2externalteststub.controllers
 
-import monocle.macros.GenLens
 import org.bson.types.ObjectId
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito.when
@@ -40,7 +39,6 @@ import uk.gov.hmrc.pillar2externalteststub.models.obligationsAndSubmissions.Obli
 import uk.gov.hmrc.pillar2externalteststub.models.obligationsAndSubmissions.SubmissionType._
 import uk.gov.hmrc.pillar2externalteststub.models.obligationsAndSubmissions._
 import uk.gov.hmrc.pillar2externalteststub.models.obligationsAndSubmissions.mongo.{AccountingPeriod, ObligationsAndSubmissionsMongoSubmission}
-import uk.gov.hmrc.pillar2externalteststub.models.organisation.{OrgDetails, TestOrganisation, TestOrganisationWithId}
 import uk.gov.hmrc.pillar2externalteststub.repositories.ObligationsAndSubmissionsRepository
 import uk.gov.hmrc.pillar2externalteststub.services.OrganisationService
 
@@ -204,12 +202,8 @@ class ObligationsAndSubmissionsControllerSpec
       }
 
       "set canAmend flag correctly based on due date" - {
-        val registrationDatePath = GenLens[TestOrganisationWithId](_.organisation)
-          .andThen(GenLens[TestOrganisation](_.orgDetails))
-          .andThen(GenLens[OrgDetails](_.registrationDate))
-
         def canAmendCheck(registrationDate: LocalDate, expectedStatus: Boolean): Assertion = {
-          val testOrg = registrationDatePath.replace(registrationDate)(domesticOrganisation)
+          val testOrg = configurableRegistrationDate.replace(registrationDate)(domesticOrganisation)
 
           when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrg))
           when(mockOasRepository.findByPillar2Id(anyString(), any[LocalDate], any[LocalDate]))

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsControllerSpec.scala
@@ -20,9 +20,9 @@ import org.bson.types.ObjectId
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito.when
 import org.mockito.stubbing.OngoingStubbing
-import org.scalatest.OptionValues
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
+import org.scalatest.{Assertion, OptionValues}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -133,6 +133,19 @@ class ObligationsAndSubmissionsControllerSpec
         secondObligationType mustBe GIR
       }
 
+      "should return the correct dueDate" in {
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
+        mockBySubmissionType(ORN_CREATE)
+
+        val result = route(app, createRequest()).value
+        status(result) mustBe OK
+
+        val jsonResponse = contentAsJson(result)
+        val dueDate      = (jsonResponse \ "success" \ "accountingPeriodDetails" \ 0 \ "dueDate").as[String]
+
+        LocalDate.parse(dueDate) mustEqual nonDomesticOrganisation.organisation.orgDetails.registrationDate.plusMonths(18)
+      }
+
       "should handle submissions with country code for ORN submission type" in {
         when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
         mockBySubmissionType(ORN_CREATE)
@@ -174,24 +187,35 @@ class ObligationsAndSubmissionsControllerSpec
         }
       }
 
-      "should set canAmend to false when current date is after due date" in {
-        val pastDueOrg = domesticOrganisation.copy(
-          organisation = domesticOrganisation.organisation.copy(
-            accountingPeriod = domesticOrganisation.organisation.accountingPeriod.copy(
-              startDate = LocalDate.of(2022, 1, 1),
-              endDate = LocalDate.of(2022, 12, 31)
+      "set canAmend flag correctly based on due date" - {
+        def canAmendCheck(registrationDate: LocalDate, expectedStatus: Boolean): Assertion = {
+          val testOrg = domesticOrganisation.copy(
+            organisation = domesticOrganisation.organisation.copy(
+              orgDetails = domesticOrganisation.organisation.orgDetails.copy(
+                registrationDate = registrationDate
+              )
             )
           )
-        )
 
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(pastDueOrg))
-        when(mockOasRepository.findByPillar2Id(anyString(), any[LocalDate], any[LocalDate])).thenReturn(Future.successful(Seq.empty))
+          when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(testOrg))
+          when(mockOasRepository.findByPillar2Id(anyString(), any[LocalDate], any[LocalDate]))
+            .thenReturn(Future.successful(Seq.empty))
 
-        val result = route(app, createRequest(fromDate = "2022-01-01", toDate = "2023-01-01")).value
-        status(result) mustBe OK
+          val result = route(app, createRequest()).value
+          status(result) mustBe OK
 
-        val jsonResponse = contentAsJson(result)
-        (jsonResponse \ "success" \ "accountingPeriodDetails" \ 0 \ "obligations" \ 0 \ "canAmend").as[Boolean] mustBe false
+          val jsonResponse = contentAsJson(result)
+          (jsonResponse \ "success" \ "accountingPeriodDetails" \ 0 \ "obligations" \ 0 \ "canAmend")
+            .as[Boolean] mustBe expectedStatus
+        }
+
+        "false when current date is over 12 months after the dueDate" in {
+          canAmendCheck(LocalDate.now.minusYears(10), expectedStatus = false)
+        }
+
+        "true when current date is within 12 months from the dueDate" in {
+          canAmendCheck(LocalDate.now(), expectedStatus = true)
+        }
       }
 
       "should return the correct response when no submissions exist" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/TestOrgDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/TestOrgDataFixture.scala
@@ -16,12 +16,13 @@
 
 package uk.gov.hmrc.pillar2externalteststub.helpers
 
+import monocle.PLens
+import monocle.macros.GenLens
 import org.scalatestplus.mockito.MockitoSugar.mock
 import uk.gov.hmrc.pillar2externalteststub.models.organisation._
 import uk.gov.hmrc.pillar2externalteststub.services.OrganisationService
 
-import java.time.Instant
-import java.time.LocalDate
+import java.time.{Instant, LocalDate}
 
 trait TestOrgDataFixture extends Pillar2DataFixture {
 
@@ -61,4 +62,9 @@ trait TestOrgDataFixture extends Pillar2DataFixture {
     pillar2Id = validPlrId,
     organisation = organisationDetails
   )
+
+  val configurableRegistrationDate: PLens[TestOrganisationWithId, TestOrganisationWithId, LocalDate, LocalDate] =
+    GenLens[TestOrganisationWithId](_.organisation)
+      .andThen(GenLens[TestOrganisation](_.orgDetails))
+      .andThen(GenLens[OrgDetails](_.registrationDate))
 }


### PR DESCRIPTION
### Changes
- `dueDate` to equal the testOrg `registrationDate` + 18 months
- `canAmend` to be `true` if the query is made within 12 months from the `dueDate`. The rejection of an amendment made after this date will be implemented in [PIL-1989](https://jira.tools.tax.service.gov.uk/browse/PIL-1989)