### PR TITLE
PIL-2044: O&S - Fix canAmend and dueDate

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsController.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsController.scala
@@ -122,7 +122,7 @@ class ObligationsAndSubmissionsController @Inject() (
     submissions: Seq[Submission]
   ): AccountingPeriodDetails = {
     val dueDate  = regDate.plusMonths(FIRST_AP_DUE_DATE_FROM_REGISTRATION_MONTHS)
-    val canAmend = LocalDate.now().isBefore(dueDate.plusMonths(AMENDMENT_WINDOW_MONTHS))
+    val canAmend = !LocalDate.now().isAfter(dueDate.plusMonths(AMENDMENT_WINDOW_MONTHS))
 
     val p2TaxReturnSubmissions = submissions
       .filter(s =>

--- a/app/uk/gov/hmrc/pillar2externalteststub/helpers/Pillar2Helper.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/helpers/Pillar2Helper.scala
@@ -29,6 +29,9 @@ object Pillar2Helper {
   val xReceiptDateHeader        = "X-Receipt-Date"
   val xOriginatingSystemHeader  = "X-Originating-System"
   val xTransmittingSystemHeader = "X-Transmitting-System"
+  val MAX_NO_SUBMISSIONS:                         Int  = 10
+  val AMENDMENT_WINDOW_MONTHS:                    Long = 12
+  val FIRST_AP_DUE_DATE_FROM_REGISTRATION_MONTHS: Long = 18
 
   def nowZonedDateTime:           String = ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS).toString
   def generateFormBundleNumber(): String = f"${Random.nextLong(1000000000000L) % 1000000000000L}%012d"

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/ObligationsAndSubmissionsISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/ObligationsAndSubmissionsISpec.scala
@@ -296,34 +296,5 @@ class ObligationsAndSubmissionsISpec
       val invalidDateRangeJson = Json.parse(invalidDateRangeResponse.body)
       (invalidDateRangeJson \ "errors" \ "text").as[String] shouldBe "Request could not be processed"
     }
-
-    "set canAmend flag correctly based on due date" in {
-      // Create accounting period with past due date
-      val pastAccountingPeriod = AccountingPeriod(
-        startDate = LocalDate.now().minusYears(3),
-        endDate = LocalDate.now().minusYears(2).minusDays(1)
-      )
-
-      insertSubmission(
-        domesticOrganisation.pillar2Id,
-        UKTR_CREATE,
-        pastAccountingPeriod
-      )
-
-      val response = getObligationsAndSubmissions(
-        domesticOrganisation.pillar2Id,
-        fromDate = pastAccountingPeriod.startDate.toString,
-        toDate = pastAccountingPeriod.endDate.toString
-      )
-
-      response.status shouldBe 200
-
-      val json                    = Json.parse(response.body)
-      val accountingPeriodDetails = (json \ "success" \ "accountingPeriodDetails").as[Seq[JsValue]]
-      val obligations             = (accountingPeriodDetails.head \ "obligations").as[Seq[JsValue]]
-
-      // canAmend should be false for past due date
-      (obligations.head \ "canAmend").as[Boolean] shouldBe false
-    }
   }
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,7 +9,9 @@ object AppDependencies {
     "org.typelevel"     %% "cats-core"                 % "2.13.0",
     "uk.gov.hmrc"       %% "bootstrap-backend-play-30" % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"        % hmrcMongoVersion,
-    "com.beachape"      %% "enumeratum-play-json"      % "1.8.2"
+    "com.beachape"      %% "enumeratum-play-json"      % "1.8.2",
+    "dev.optics"        %% "monocle-core"              % "3.3.0",
+    "dev.optics"        %% "monocle-macro"             % "3.3.0"
   )
 
   val test: Seq[ModuleID] = Seq(

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsControllerSpec.scala
@@ -30,7 +30,7 @@ import play.api.libs.json.JsValue
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.api.{Application, inject}
-import uk.gov.hmrc.pillar2externalteststub.helpers.Pillar2Helper.ServerErrorPlrId
+import uk.gov.hmrc.pillar2externalteststub.helpers.Pillar2Helper.{AMENDMENT_WINDOW_MONTHS, FIRST_AP_DUE_DATE_FROM_REGISTRATION_MONTHS, ServerErrorPlrId}
 import uk.gov.hmrc.pillar2externalteststub.helpers.{ObligationsAndSubmissionsDataFixture, TestOrgDataFixture, UKTRDataFixture}
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.{ETMPInternalServerError, NoDataFound, RequestCouldNotBeProcessed}
 import uk.gov.hmrc.pillar2externalteststub.models.error.OrganisationNotFound
@@ -202,6 +202,8 @@ class ObligationsAndSubmissionsControllerSpec
       }
 
       "set canAmend flag correctly based on due date" - {
+        val boundaryDate = LocalDate.now.minusMonths(FIRST_AP_DUE_DATE_FROM_REGISTRATION_MONTHS + AMENDMENT_WINDOW_MONTHS)
+
         def canAmendCheck(registrationDate: LocalDate, expectedStatus: Boolean): Assertion = {
           val testOrg = configurableRegistrationDate.replace(registrationDate)(domesticOrganisation)
 
@@ -216,11 +218,11 @@ class ObligationsAndSubmissionsControllerSpec
         }
 
         "false when current date is over 12 months after the dueDate" in {
-          canAmendCheck(LocalDate.now.minusYears(10), expectedStatus = false)
+          canAmendCheck(boundaryDate.minusDays(1), expectedStatus = false)
         }
 
         "true when current date is within 12 months from the dueDate" in {
-          canAmendCheck(LocalDate.now(), expectedStatus = true)
+          canAmendCheck(boundaryDate, expectedStatus = true)
         }
       }
 

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/TestOrgDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/TestOrgDataFixture.scala
@@ -16,12 +16,13 @@
 
 package uk.gov.hmrc.pillar2externalteststub.helpers
 
+import monocle.PLens
+import monocle.macros.GenLens
 import org.scalatestplus.mockito.MockitoSugar.mock
 import uk.gov.hmrc.pillar2externalteststub.models.organisation._
 import uk.gov.hmrc.pillar2externalteststub.services.OrganisationService
 
-import java.time.Instant
-import java.time.LocalDate
+import java.time.{Instant, LocalDate}
 
 trait TestOrgDataFixture extends Pillar2DataFixture {
 
@@ -61,4 +62,9 @@ trait TestOrgDataFixture extends Pillar2DataFixture {
     pillar2Id = validPlrId,
     organisation = organisationDetails
   )
+
+  val configurableRegistrationDate: PLens[TestOrganisationWithId, TestOrganisationWithId, LocalDate, LocalDate] =
+    GenLens[TestOrganisationWithId](_.organisation)
+      .andThen(GenLens[TestOrganisation](_.orgDetails))
+      .andThen(GenLens[OrgDetails](_.registrationDate))
 }


### PR DESCRIPTION
_Replaces (https://github.com/hmrc/pillar2-external-test-stub/pull/77 after https://github.com/hmrc/pillar2-external-test-stub/pull/78)_
### Changes
- `dueDate` to equal the testOrg `registrationDate` + 18 months
- `canAmend` to be `true` if the query is made within 12 months from the `dueDate`. The rejection of an amendment made after this date will be implemented in [PIL-1989](https://jira.tools.tax.service.gov.uk/browse/PIL-1989)