### PR TITLE
PIL-1990 - Add validation for IIR and UTPR amounts when MTT obligation is false

### DIFF
--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/UKTRDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/UKTRDataFixture.scala
@@ -42,7 +42,7 @@ trait UKTRDataFixture extends Pillar2DataFixture with TestOrgDataFixture {
   val validRequestBody: JsObject = Json.obj(
     "accountingPeriodFrom" -> accountingPeriod.startDate.toString,
     "accountingPeriodTo"   -> accountingPeriod.endDate.toString,
-    "obligationMTT"        -> false,
+    "obligationMTT"        -> true,
     "electionUKGAAP"       -> false,
     "liabilities" -> Json.obj(
       "electionDTTSingleMember"  -> true,

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturnSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturnSpec.scala
@@ -189,6 +189,8 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
       val invalidReturn = validLiabilityReturn.copy(
         obligationMTT = false,
         liabilities = validLiabilityReturn.liabilities.copy(
+          electionUTPRSingleMember = false,
+          numberSubGroupUTPR = 0,
           totalLiability = BigDecimal(200),
           totalLiabilityIIR = BigDecimal(100),
           totalLiabilityUTPR = BigDecimal(0),
@@ -197,6 +199,7 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
           )
         )
       )
+
       val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
       result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
     }
@@ -205,17 +208,20 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
       val invalidReturn = validLiabilityReturn.copy(
         obligationMTT = false,
         liabilities = validLiabilityReturn.liabilities.copy(
+          electionDTTSingleMember = false,
+          numberSubGroupDTT = 0,
+          electionUTPRSingleMember = false,
+          numberSubGroupUTPR = 0,
           totalLiability = BigDecimal(100),
-          totalLiabilityIIR = BigDecimal(0),
+          totalLiabilityDTT = BigDecimal(0),
+          totalLiabilityIIR = BigDecimal(100),
           totalLiabilityUTPR = BigDecimal(0),
-          liableEntities = Seq(
-            validLiabilityReturn.liabilities.liableEntities.head.copy(
-              amountOwedIIR = BigDecimal(100),
-              amountOwedUTPR = BigDecimal(0)
-            )
+          liableEntities = validLiabilityReturn.liabilities.liableEntities.map(entity =>
+            entity.copy(amountOwedDTT = BigDecimal(0), amountOwedIIR = BigDecimal(100), amountOwedUTPR = BigDecimal(0))
           )
         )
       )
+
       val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
       result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
     }
@@ -224,6 +230,8 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
       val invalidReturn = validLiabilityReturn.copy(
         obligationMTT = false,
         liabilities = validLiabilityReturn.liabilities.copy(
+          electionUTPRSingleMember = false,
+          numberSubGroupUTPR = 0,
           totalLiability = BigDecimal(200),
           totalLiabilityIIR = BigDecimal(0),
           totalLiabilityUTPR = BigDecimal(100),
@@ -232,6 +240,7 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
           )
         )
       )
+
       val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
       result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
     }
@@ -240,17 +249,20 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
       val invalidReturn = validLiabilityReturn.copy(
         obligationMTT = false,
         liabilities = validLiabilityReturn.liabilities.copy(
+          electionDTTSingleMember = false,
+          numberSubGroupDTT = 0,
+          electionUTPRSingleMember = false,
+          numberSubGroupUTPR = 0,
           totalLiability = BigDecimal(100),
+          totalLiabilityDTT = BigDecimal(0),
           totalLiabilityIIR = BigDecimal(0),
-          totalLiabilityUTPR = BigDecimal(0),
-          liableEntities = Seq(
-            validLiabilityReturn.liabilities.liableEntities.head.copy(
-              amountOwedIIR = BigDecimal(0),
-              amountOwedUTPR = BigDecimal(100)
-            )
+          totalLiabilityUTPR = BigDecimal(100),
+          liableEntities = validLiabilityReturn.liabilities.liableEntities.map(entity =>
+            entity.copy(amountOwedDTT = BigDecimal(0), amountOwedIIR = BigDecimal(0), amountOwedUTPR = BigDecimal(100))
           )
         )
       )
+
       val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
       result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
     }
@@ -259,6 +271,8 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
       val validReturn = validLiabilityReturn.copy(
         obligationMTT = false,
         liabilities = validLiabilityReturn.liabilities.copy(
+          electionUTPRSingleMember = false,
+          numberSubGroupUTPR = 0,
           totalLiability = BigDecimal(100),
           totalLiabilityIIR = BigDecimal(0),
           totalLiabilityUTPR = BigDecimal(0),
@@ -266,6 +280,7 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
             validLiabilityReturn.liabilities.liableEntities.map(entity => entity.copy(amountOwedIIR = BigDecimal(0), amountOwedUTPR = BigDecimal(0)))
         )
       )
+
       val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(validReturn)), 5.seconds)
       result mustEqual valid(validReturn)
     }

--- a/test/uk/gov/hmrc/pillar2externalteststub/services/UKTRServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/services/UKTRServiceSpec.scala
@@ -183,12 +183,16 @@ class UKTRServiceSpec
       "for liability returns" - {
         "should fail when total liability does not match sum of components" in {
           when(mockOrgService.getOrganisation(eqTo(validPlrId)))
-            .thenReturn(Future.successful(domesticOrganisation))
+            .thenReturn(Future.successful(nonDomesticOrganisation))
 
           val liabilityReturn = liabilitySubmission.asInstanceOf[UKTRLiabilityReturn]
           val invalidSubmission = liabilityReturn.copy(
+            obligationMTT = true,
             liabilities = liabilityReturn.liabilities.copy(
-              totalLiability = BigDecimal(50000.00)
+              totalLiability = BigDecimal(50000.00),
+              totalLiabilityDTT = BigDecimal(100),
+              totalLiabilityIIR = BigDecimal(100),
+              totalLiabilityUTPR = BigDecimal(100)
             )
           )
 
@@ -204,6 +208,8 @@ class UKTRServiceSpec
           val invalidSubmission = liabilityReturn.copy(
             obligationMTT = false,
             liabilities = liabilityReturn.liabilities.copy(
+              electionUTPRSingleMember = false,
+              numberSubGroupUTPR = 0,
               totalLiability = BigDecimal(200),
               totalLiabilityIIR = BigDecimal(100),
               totalLiabilityUTPR = BigDecimal(0),
@@ -224,6 +230,8 @@ class UKTRServiceSpec
           val invalidSubmission = liabilityReturn.copy(
             obligationMTT = false,
             liabilities = liabilityReturn.liabilities.copy(
+              electionUTPRSingleMember = false,
+              numberSubGroupUTPR = 0,
               totalLiability = BigDecimal(200),
               totalLiabilityIIR = BigDecimal(0),
               totalLiabilityUTPR = BigDecimal(100),
@@ -246,6 +254,8 @@ class UKTRServiceSpec
           val invalidSubmission = liabilityReturn.copy(
             obligationMTT = false,
             liabilities = liabilityReturn.liabilities.copy(
+              electionUTPRSingleMember = false,
+              numberSubGroupUTPR = 0,
               totalLiability = BigDecimal(200),
               totalLiabilityIIR = BigDecimal(100),
               totalLiabilityUTPR = BigDecimal(0),
@@ -268,6 +278,8 @@ class UKTRServiceSpec
           val invalidSubmission = liabilityReturn.copy(
             obligationMTT = false,
             liabilities = liabilityReturn.liabilities.copy(
+              electionUTPRSingleMember = false,
+              numberSubGroupUTPR = 0,
               totalLiability = BigDecimal(200),
               totalLiabilityIIR = BigDecimal(0),
               totalLiabilityUTPR = BigDecimal(100),
@@ -294,6 +306,8 @@ class UKTRServiceSpec
           val validSubmission = liabilityReturn.copy(
             obligationMTT = false,
             liabilities = liabilityReturn.liabilities.copy(
+              electionUTPRSingleMember = false,
+              numberSubGroupUTPR = 0,
               totalLiability = BigDecimal(100),
               totalLiabilityIIR = BigDecimal(0),
               totalLiabilityUTPR = BigDecimal(0),
@@ -326,6 +340,8 @@ class UKTRServiceSpec
           val validSubmission = liabilityReturn.copy(
             obligationMTT = false,
             liabilities = liabilityReturn.liabilities.copy(
+              electionUTPRSingleMember = false,
+              numberSubGroupUTPR = 0,
               totalLiability = BigDecimal(100),
               totalLiabilityIIR = BigDecimal(0),
               totalLiabilityUTPR = BigDecimal(0),


### PR DESCRIPTION
When `obligationMTT` is false, both IIR and UTPR amounts must be zero (both totals and individual entity amounts). If not, error code 093 (Invalid Return) is returned.

Changes:
- Added new validation rule `nonMTTAmountsRule` in `UKTRLiabilityReturn.scala`
- Added unit tests in `UKTRLiabilityReturnSpec.scala` 
- Added integration tests in `UKTRServiceSpec.scala`