### PR TITLE
PIL-1995 ORN Implement BTN Active Check

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/helpers/SubscriptionHelper.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/helpers/SubscriptionHelper.scala
@@ -32,33 +32,7 @@ object SubscriptionHelper {
       case "XEPLR0123456500" => (InternalServerError, ServerError500.response)
       case "XEPLR0123456503" => (ServiceUnavailable, ServiceUnavailable503.response)
       case "XEPLR5555555554" => (NotFound, NotFoundSubscription.response)
-
-      case "XEPLR0000000301" => (Ok, successfulDomesticOnlyResponseWithActiveBtnFlag)
-      case "XEPLR0000000302" => (Ok, successfulDomesticOnlyResponseWithInactiveBtnFlag)
-      case "XEPLR0000000303" => (Ok, successfulNonDomesticResponseWithActiveBtnFlag)
-      case "XEPLR0000000304" => (Ok, successfulNonDomesticResponseWithInactiveBtnFlag)
-
       case "XEPLR1234567890" => (Ok, successfulNonDomesticResponse)
       case _                 => (Ok, successfulDomesticOnlyResponse)
     }
-
-  private def successfulDomesticOnlyResponseWithActiveBtnFlag: SubscriptionSuccessResponse =
-    successfulDomesticOnlyResponse.copy(
-      accountStatus = AccountStatus(inactive = true)
-    )
-
-  private def successfulDomesticOnlyResponseWithInactiveBtnFlag: SubscriptionSuccessResponse =
-    successfulDomesticOnlyResponse.copy(
-      accountStatus = AccountStatus(inactive = false)
-    )
-
-  private def successfulNonDomesticResponseWithActiveBtnFlag: SubscriptionSuccessResponse =
-    successfulNonDomesticResponse.copy(
-      accountStatus = AccountStatus(inactive = true)
-    )
-
-  private def successfulNonDomesticResponseWithInactiveBtnFlag: SubscriptionSuccessResponse =
-    successfulNonDomesticResponse.copy(
-      accountStatus = AccountStatus(inactive = false)
-    )
 }

--- a/app/uk/gov/hmrc/pillar2externalteststub/helpers/SubscriptionHelper.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/helpers/SubscriptionHelper.scala
@@ -29,24 +29,19 @@ object SubscriptionHelper {
 
   def retrieveSubscription(plrReference: String): (Status, SubscriptionResponse) =
     plrReference match {
-      // Error scenarios
       case "XEPLR0123456500" => (InternalServerError, ServerError500.response)
       case "XEPLR0123456503" => (ServiceUnavailable, ServiceUnavailable503.response)
       case "XEPLR5555555554" => (NotFound, NotFoundSubscription.response)
-      
-      // BTN flag test scenarios
-      case "XEPLR0000000301" => (Ok, successfulDomesticOnlyResponseWithActiveBtnFlag)     // BTN active (inactive = true)
-      case "XEPLR0000000302" => (Ok, successfulDomesticOnlyResponseWithInactiveBtnFlag)   // BTN inactive (inactive = false)
-      case "XEPLR0000000303" => (Ok, successfulNonDomesticResponseWithActiveBtnFlag)      // Non-domestic with BTN active
-      case "XEPLR0000000304" => (Ok, successfulNonDomesticResponseWithInactiveBtnFlag)    // Non-domestic with BTN inactive
-      
-      // Default scenarios
+
+      case "XEPLR0000000301" => (Ok, successfulDomesticOnlyResponseWithActiveBtnFlag)
+      case "XEPLR0000000302" => (Ok, successfulDomesticOnlyResponseWithInactiveBtnFlag)
+      case "XEPLR0000000303" => (Ok, successfulNonDomesticResponseWithActiveBtnFlag)
+      case "XEPLR0000000304" => (Ok, successfulNonDomesticResponseWithInactiveBtnFlag)
+
       case "XEPLR1234567890" => (Ok, successfulNonDomesticResponse)
       case _                 => (Ok, successfulDomesticOnlyResponse)
     }
 
-  // Additional subscription responses for BTN testing
-  
   private def successfulDomesticOnlyResponseWithActiveBtnFlag: SubscriptionSuccessResponse =
     successfulDomesticOnlyResponse.copy(
       accountStatus = AccountStatus(inactive = true)

--- a/app/uk/gov/hmrc/pillar2externalteststub/helpers/SubscriptionHelper.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/helpers/SubscriptionHelper.scala
@@ -29,10 +29,41 @@ object SubscriptionHelper {
 
   def retrieveSubscription(plrReference: String): (Status, SubscriptionResponse) =
     plrReference match {
+      // Error scenarios
       case "XEPLR0123456500" => (InternalServerError, ServerError500.response)
       case "XEPLR0123456503" => (ServiceUnavailable, ServiceUnavailable503.response)
       case "XEPLR5555555554" => (NotFound, NotFoundSubscription.response)
+      
+      // BTN flag test scenarios
+      case "XEPLR0000000301" => (Ok, successfulDomesticOnlyResponseWithActiveBtnFlag)     // BTN active (inactive = true)
+      case "XEPLR0000000302" => (Ok, successfulDomesticOnlyResponseWithInactiveBtnFlag)   // BTN inactive (inactive = false)
+      case "XEPLR0000000303" => (Ok, successfulNonDomesticResponseWithActiveBtnFlag)      // Non-domestic with BTN active
+      case "XEPLR0000000304" => (Ok, successfulNonDomesticResponseWithInactiveBtnFlag)    // Non-domestic with BTN inactive
+      
+      // Default scenarios
       case "XEPLR1234567890" => (Ok, successfulNonDomesticResponse)
       case _                 => (Ok, successfulDomesticOnlyResponse)
     }
+
+  // Additional subscription responses for BTN testing
+  
+  private def successfulDomesticOnlyResponseWithActiveBtnFlag: SubscriptionSuccessResponse =
+    successfulDomesticOnlyResponse.copy(
+      accountStatus = AccountStatus(inactive = true)
+    )
+
+  private def successfulDomesticOnlyResponseWithInactiveBtnFlag: SubscriptionSuccessResponse =
+    successfulDomesticOnlyResponse.copy(
+      accountStatus = AccountStatus(inactive = false)
+    )
+
+  private def successfulNonDomesticResponseWithActiveBtnFlag: SubscriptionSuccessResponse =
+    successfulNonDomesticResponse.copy(
+      accountStatus = AccountStatus(inactive = true)
+    )
+
+  private def successfulNonDomesticResponseWithInactiveBtnFlag: SubscriptionSuccessResponse =
+    successfulNonDomesticResponse.copy(
+      accountStatus = AccountStatus(inactive = false)
+    )
 }

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/organisation/TestOrganisation.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/organisation/TestOrganisation.scala
@@ -46,7 +46,7 @@ case class TestOrganisationRequest(
 case class TestOrganisation(
   orgDetails:       OrgDetails,
   accountingPeriod: AccountingPeriod,
-  accountStatus:    AccountStatus = AccountStatus(inactive = false),
+  accountStatus:    AccountStatus,
   lastUpdated:      Instant = Instant.now()
 ) {
   def withPillar2Id(pillar2Id: String): TestOrganisationWithId =
@@ -112,7 +112,7 @@ object TestOrganisation {
     (
       (__ \ "orgDetails").read[OrgDetails] and
         (__ \ "accountingPeriod").read[AccountingPeriod] and
-        (__ \ "accountStatus").readWithDefault[AccountStatus](AccountStatus(inactive = false)) and
+        (__ \ "accountStatus").read[AccountStatus] and
         (__ \ "lastUpdated").read[Instant](mongoInstantFormat)
     )(TestOrganisation.apply _)
 
@@ -130,7 +130,7 @@ object TestOrganisation {
     (
       (__ \ "orgDetails").read[OrgDetails] and
         (__ \ "accountingPeriod").read[AccountingPeriod] and
-        (__ \ "accountStatus").readWithDefault[AccountStatus](AccountStatus(inactive = false)) and
+        (__ \ "accountStatus").read[AccountStatus] and
         (__ \ "lastUpdated").read[Instant](apiInstantFormat)
     )(TestOrganisation.apply _)
 

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/organisation/TestOrganisation.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/organisation/TestOrganisation.scala
@@ -39,8 +39,7 @@ case class AccountStatus(
 
 case class TestOrganisationRequest(
   orgDetails:       OrgDetails,
-  accountingPeriod: AccountingPeriod,
-  accountStatus:    Option[AccountStatus] = None
+  accountingPeriod: AccountingPeriod
 )
 
 case class TestOrganisation(
@@ -105,7 +104,8 @@ object TestOrganisation {
     TestOrganisation(
       orgDetails = request.orgDetails,
       accountingPeriod = request.accountingPeriod,
-      accountStatus = request.accountStatus.getOrElse(AccountStatus(inactive = false))
+      //Initialise as active until we get a BTN
+      accountStatus = AccountStatus(inactive = false)
     )
 
   private val mongoReads: Reads[TestOrganisation] =

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNValidationRules.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNValidationRules.scala
@@ -20,12 +20,10 @@ import uk.gov.hmrc.pillar2externalteststub.models.common.BaseSubmissionValidatio
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError._
 import uk.gov.hmrc.pillar2externalteststub.models.organisation.TestOrganisationWithId
-import uk.gov.hmrc.pillar2externalteststub.services.OrganisationService
 import uk.gov.hmrc.pillar2externalteststub.validation.ValidationResult.{invalid, valid}
 import uk.gov.hmrc.pillar2externalteststub.validation.{ValidationError, ValidationRule}
 
 import java.time.LocalDate
-import scala.concurrent.{ExecutionContext, Future}
 
 case class ORNValidationError(error: ETMPError) extends ValidationError {
   override def errorCode:    String = error.code
@@ -42,18 +40,13 @@ object ORNValidationRules {
     }
   }
 
-  /**
-   * BTN flag status validation rule
-   * Checks if the BTN flag is active (accountStatus.inactive = true)
-   * Returns error 003 (RequestCouldNotBeProcessed) if BTN flag is active
-   */
-  def btnStatusRule(pillar2Id: String)(implicit organisationService: OrganisationService, ec: ExecutionContext): Future[ValidationRule[ORNRequest]] =
-    organisationService.isBtnFlagActive(pillar2Id).map { isBtnActive =>
-      ValidationRule[ORNRequest] { request =>
-        if (isBtnActive) invalid(ORNValidationError(RequestCouldNotBeProcessed))
-        else valid(request)
-      }
+  def btnStatusRule(testOrg: TestOrganisationWithId): ValidationRule[ORNRequest] = {
+    val isBtnActive = testOrg.organisation.accountStatus.inactive
+    ValidationRule[ORNRequest] { request =>
+      if (isBtnActive) invalid(ORNValidationError(RequestCouldNotBeProcessed))
+      else valid(request)
     }
+  }
 
   def filedDateGIRRule: ValidationRule[ORNRequest] =
     ValidationRule[ORNRequest] { request =>

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNValidator.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNValidator.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.pillar2externalteststub.models.orn
 import uk.gov.hmrc.pillar2externalteststub.models.common.BaseSubmissionValidationRules.{accountingPeriodMatchesOrgRule, accountingPeriodSanityCheckRule}
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.{InvalidReturn, NoActiveSubscription}
 import uk.gov.hmrc.pillar2externalteststub.models.error.OrganisationNotFound
-import uk.gov.hmrc.pillar2externalteststub.models.orn.ORNValidationRules.{countryISOComplianceRule, domesticOnlyRule, filedDateGIRRule}
+import uk.gov.hmrc.pillar2externalteststub.models.orn.ORNValidationRules.{btnStatusRule, countryISOComplianceRule, domesticOnlyRule, filedDateGIRRule}
 import uk.gov.hmrc.pillar2externalteststub.services.OrganisationService
 import uk.gov.hmrc.pillar2externalteststub.validation.ValidationResult.invalid
 import uk.gov.hmrc.pillar2externalteststub.validation.{FailFast, ValidationRule}
@@ -36,14 +36,18 @@ object ORNValidator {
   ): Future[ValidationRule[ORNRequest]] =
     organisationService
       .getOrganisation(pillar2Id)
-      .map { org =>
-        ValidationRule.compose(
-          domesticOnlyRule(org),
-          countryISOComplianceRule,
-          accountingPeriodMatchesOrgRule[ORNRequest](org, ORNValidationError(InvalidReturn)),
-          accountingPeriodSanityCheckRule[ORNRequest](ORNValidationError(InvalidReturn)),
-          filedDateGIRRule
-        )(FailFast)
+      .flatMap { org =>
+        // Get the BTN status rule asynchronously
+        btnStatusRule(pillar2Id).map { btnRule =>
+          ValidationRule.compose(
+            domesticOnlyRule(org),
+            btnRule, // Add BTN status validation
+            countryISOComplianceRule,
+            accountingPeriodMatchesOrgRule[ORNRequest](org, ORNValidationError(InvalidReturn)),
+            accountingPeriodSanityCheckRule[ORNRequest](ORNValidationError(InvalidReturn)),
+            filedDateGIRRule
+          )(FailFast)
+        }
       }
       .recover { case _: OrganisationNotFound =>
         ValidationRule[ORNRequest](_ => invalid(ORNValidationError(NoActiveSubscription)))

--- a/app/uk/gov/hmrc/pillar2externalteststub/services/BTNService.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/services/BTNService.scala
@@ -24,6 +24,7 @@ import uk.gov.hmrc.pillar2externalteststub.models.btn.BTNValidator
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.ETMPInternalServerError
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.TaxObligationAlreadyFulfilled
 import uk.gov.hmrc.pillar2externalteststub.models.obligationsAndSubmissions.SubmissionType.BTN
+import uk.gov.hmrc.pillar2externalteststub.models.organisation.AccountStatus
 import uk.gov.hmrc.pillar2externalteststub.repositories.{BTNSubmissionRepository, ObligationsAndSubmissionsRepository}
 import uk.gov.hmrc.pillar2externalteststub.validation.ValidationRule
 
@@ -47,7 +48,19 @@ class BTNService @Inject() (
       _            <- checkForExistingSubmission(pillar2Id, request)
       submissionId <- btnRepository.insert(pillar2Id, request)
       _            <- oasRepository.insert(request, pillar2Id, submissionId)
+      _            <- updateOrganisationBtnStatus(pillar2Id, active = true)
     } yield true
+  }
+
+  private def updateOrganisationBtnStatus(pillar2Id: String, active: Boolean): Future[Unit] = {
+    logger.info(s"Updating BTN status for pillar2Id: $pillar2Id to active: $active")
+
+    organisationService.getOrganisation(pillar2Id).flatMap { org =>
+      val updatedOrg = org.organisation.copy(
+        accountStatus = AccountStatus(inactive = active)
+      )
+      organisationService.updateOrganisation(pillar2Id, updatedOrg).map(_ => ())
+    }
   }
 
   private def validateRequest(validator: ValidationRule[BTNRequest], request: BTNRequest): Future[Unit] =

--- a/app/uk/gov/hmrc/pillar2externalteststub/services/OrganisationService.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/services/OrganisationService.scala
@@ -48,31 +48,19 @@ class OrganisationService @Inject() (
         case None      => Future.failed(OrganisationNotFound(pillar2Id))
       }
 
-  /**
-   * Get organisation with enriched subscription data including BTN flag status
-   * This method calls the subscription service (EPID 1457) to get the latest account status
-   */
   def getOrganisationWithSubscription(pillar2Id: String): Future[TestOrganisationWithId] =
     for {
-      org <- getOrganisation(pillar2Id)
+      org              <- getOrganisation(pillar2Id)
       subscriptionData <- getSubscriptionData(pillar2Id)
       enrichedOrg = enrichOrganisationWithSubscription(org, subscriptionData)
     } yield enrichedOrg
 
-  /**
-   * Get BTN flag status for a given pillar2Id
-   * Returns true if BTN flag is active (inactive = true), false otherwise
-   */
   def getBtnFlagStatus(pillar2Id: String): Future[Boolean] =
     getSubscriptionData(pillar2Id).map {
       case success: SubscriptionSuccessResponse => success.accountStatus.inactive
-      case _ => false // Default to false if subscription data is not available
+      case _ => false
     }
 
-  /**
-   * Check if BTN flag is active (inactive = true)
-   * This is the method that should be used in validation rules
-   */
   def isBtnFlagActive(pillar2Id: String): Future[Boolean] = getBtnFlagStatus(pillar2Id)
 
   def updateOrganisation(pillar2Id: String, organisation: TestOrganisation): Future[TestOrganisationWithId] = {
@@ -93,32 +81,22 @@ class OrganisationService @Inject() (
         repository.delete(pillar2Id).map(_ => ())
     }
 
-  // Private helper methods
-
-  /**
-   * Retrieve subscription data using the existing SubscriptionHelper (EPID 1457)
-   */
   private def getSubscriptionData(pillar2Id: String): Future[SubscriptionResponse] =
     Future.successful {
       val (_, response) = SubscriptionHelper.retrieveSubscription(pillar2Id)
       response
     }
 
-  /**
-   * Enrich organisation data with subscription information
-   */
   private def enrichOrganisationWithSubscription(
-    org: TestOrganisationWithId, 
+    org:              TestOrganisationWithId,
     subscriptionData: SubscriptionResponse
-  ): TestOrganisationWithId = {
+  ): TestOrganisationWithId =
     subscriptionData match {
       case success: SubscriptionSuccessResponse =>
         val updatedAccountStatus = AccountStatus(inactive = success.accountStatus.inactive)
-        val updatedOrganisation = org.organisation.copy(accountStatus = updatedAccountStatus)
+        val updatedOrganisation  = org.organisation.copy(accountStatus = updatedAccountStatus)
         org.copy(organisation = updatedOrganisation)
       case _ =>
-        // If subscription data is not available, keep the existing organisation data
         org
     }
-  }
 }

--- a/app/uk/gov/hmrc/pillar2externalteststub/services/UKTRService.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/services/UKTRService.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.pillar2externalteststub.services
 import play.api.Logging
 import uk.gov.hmrc.pillar2externalteststub.helpers.Pillar2Helper.{AMENDMENT_WINDOW_MONTHS, FIRST_AP_DUE_DATE_FROM_REGISTRATION_MONTHS, generateChargeReference}
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError._
-import uk.gov.hmrc.pillar2externalteststub.models.organisation.AccountStatus
 import uk.gov.hmrc.pillar2externalteststub.models.uktr.LiabilityReturnSuccess.successfulUKTRResponse
 import uk.gov.hmrc.pillar2externalteststub.models.uktr.NilReturnSuccess.successfulNilReturnResponse
 import uk.gov.hmrc.pillar2externalteststub.models.uktr._
@@ -46,7 +45,7 @@ class UKTRService @Inject() (
       _         <- validateRequest(validator, request)
       _         <- validateNoExistingSubmission(pillar2Id)
       _         <- processSubmission(pillar2Id, request)
-      _         <- updateOrganisationBtnStatus(pillar2Id, active = false)
+      _         <- organisationService.makeOrganisatonActive(pillar2Id)
     } yield createResponse(request)
   }
 
@@ -58,7 +57,7 @@ class UKTRService @Inject() (
       validator          <- getValidator(pillar2Id, request)
       _                  <- validateRequest(validator, request)
       _                  <- processSubmission(pillar2Id, request, isAmendment = true)
-      _                  <- updateOrganisationBtnStatus(pillar2Id, active = false)
+      _                  <- organisationService.makeOrganisatonActive(pillar2Id)
     } yield createResponse(request, existingSubmission.chargeReference)
   }
 
@@ -128,17 +127,6 @@ class UKTRService @Inject() (
         }
       case _ => Future.failed(ETMPBadRequest())
     }
-
-  private def updateOrganisationBtnStatus(pillar2Id: String, active: Boolean): Future[Unit] = {
-    logger.info(s"Updating BTN status for pillar2Id: $pillar2Id to active: $active")
-
-    organisationService.getOrganisation(pillar2Id).flatMap { org =>
-      val updatedOrg = org.organisation.copy(
-        accountStatus = AccountStatus(inactive = active)
-      )
-      organisationService.updateOrganisation(pillar2Id, updatedOrg).map(_ => ())
-    }
-  }
 
   private def createResponse(request: UKTRSubmission, existingChargeRef: Option[String] = None): UKTRResponse = request match {
     case _: UKTRLiabilityReturn => successfulUKTRResponse(existingChargeRef)

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/BTNISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/BTNISpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.pillar2externalteststub
 
-import org.mockito.ArgumentMatchers.{eq => eqTo}
+import org.mockito.ArgumentMatchers.{eq => eqTo, any}
 import org.mockito.Mockito.when
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
@@ -33,6 +33,7 @@ import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import uk.gov.hmrc.pillar2externalteststub.helpers.{BTNDataFixture, ObligationsAndSubmissionsDataFixture, TestOrgDataFixture}
 import uk.gov.hmrc.pillar2externalteststub.models.btn.BTNRequest
 import uk.gov.hmrc.pillar2externalteststub.models.btn.mongo.BTNSubmission
+import uk.gov.hmrc.pillar2externalteststub.models.organisation.TestOrganisation
 import uk.gov.hmrc.pillar2externalteststub.repositories.BTNSubmissionRepository
 import uk.gov.hmrc.pillar2externalteststub.services.OrganisationService
 
@@ -96,6 +97,7 @@ class BTNISpec
   "BTN submission endpoint" should {
     "successfully save and retrieve BTN submissions" in {
       when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
+      when(mockOrgService.updateOrganisation(eqTo(validPlrId), any[TestOrganisation])).thenReturn(Future.successful(organisationWithId))
 
       val response = submitBTN(validPlrId, validBTNRequest)
       response.status shouldBe 201
@@ -110,6 +112,7 @@ class BTNISpec
 
     "fail with TaxObligationAlreadyFulfilled when submitting twice in a row" in {
       when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
+      when(mockOrgService.updateOrganisation(eqTo(validPlrId), any[TestOrganisation])).thenReturn(Future.successful(organisationWithId))
 
       // First submission should succeed
       val firstResponse = submitBTN(validPlrId, validBTNRequest)
@@ -130,6 +133,9 @@ class BTNISpec
     }
 
     "support only one accountingPeriod per Pillar2 ID" in {
+      when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
+      when(mockOrgService.updateOrganisation(eqTo(validPlrId), any[TestOrganisation])).thenReturn(Future.successful(organisationWithId))
+      
       submitBTN(validPlrId, validBTNRequest).status shouldBe 201
 
       val secondRequest = validBTNRequest.copy(

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/BTNISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/BTNISpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.pillar2externalteststub
 
-import org.mockito.ArgumentMatchers.{eq => eqTo, any}
+import org.mockito.ArgumentMatchers.{eq => eqTo}
 import org.mockito.Mockito.when
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
@@ -33,7 +33,6 @@ import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import uk.gov.hmrc.pillar2externalteststub.helpers.{BTNDataFixture, ObligationsAndSubmissionsDataFixture, TestOrgDataFixture}
 import uk.gov.hmrc.pillar2externalteststub.models.btn.BTNRequest
 import uk.gov.hmrc.pillar2externalteststub.models.btn.mongo.BTNSubmission
-import uk.gov.hmrc.pillar2externalteststub.models.organisation.TestOrganisation
 import uk.gov.hmrc.pillar2externalteststub.repositories.BTNSubmissionRepository
 import uk.gov.hmrc.pillar2externalteststub.services.OrganisationService
 
@@ -97,7 +96,7 @@ class BTNISpec
   "BTN submission endpoint" should {
     "successfully save and retrieve BTN submissions" in {
       when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
-      when(mockOrgService.updateOrganisation(eqTo(validPlrId), any[TestOrganisation])).thenReturn(Future.successful(organisationWithId))
+      when(mockOrgService.makeOrganisatonInactive(eqTo(validPlrId))).thenReturn(Future.successful(()))
 
       val response = submitBTN(validPlrId, validBTNRequest)
       response.status shouldBe 201
@@ -112,7 +111,7 @@ class BTNISpec
 
     "fail with TaxObligationAlreadyFulfilled when submitting twice in a row" in {
       when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
-      when(mockOrgService.updateOrganisation(eqTo(validPlrId), any[TestOrganisation])).thenReturn(Future.successful(organisationWithId))
+      when(mockOrgService.makeOrganisatonInactive(eqTo(validPlrId))).thenReturn(Future.successful(()))
 
       // First submission should succeed
       val firstResponse = submitBTN(validPlrId, validBTNRequest)
@@ -134,7 +133,7 @@ class BTNISpec
 
     "support only one accountingPeriod per Pillar2 ID" in {
       when(mockOrgService.getOrganisation(eqTo(validPlrId))).thenReturn(Future.successful(organisationWithId))
-      when(mockOrgService.updateOrganisation(eqTo(validPlrId), any[TestOrganisation])).thenReturn(Future.successful(organisationWithId))
+      when(mockOrgService.makeOrganisatonInactive(eqTo(validPlrId))).thenReturn(Future.successful(()))
       
       submitBTN(validPlrId, validBTNRequest).status shouldBe 201
 

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/UKTRSubmissionISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/UKTRSubmissionISpec.scala
@@ -61,7 +61,8 @@ class UKTRSubmissionISpec
 
   private val testOrg = TestOrganisation(
     orgDetails = orgDetails,
-    accountingPeriod = accountingPeriod
+    accountingPeriod = accountingPeriod,
+    accountStatus = AccountStatus(inactive = false)
   )
 
   private val testOrgWithId = TestOrganisationWithId(

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/actions/AuthActionFilterSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/actions/AuthActionFilterSpec.scala
@@ -45,9 +45,10 @@ class AuthActionFilterSpec extends AnyWordSpec with Matchers with ScalaFutures w
 
     "throw ETMPBadRequest" when {
       def testHeader(header: String, invalidValue: String = ""): Assertion = {
-        val headers = {
-          val filteredHeaders = hipHeaders.filterNot(_._1 == header)
-          if (invalidValue.isEmpty) filteredHeaders else filteredHeaders :+ (header -> invalidValue)
+        val headers = if (invalidValue.isEmpty) {
+          hipHeaders.filterNot(_._1 == header)
+        } else {
+          hipHeaders.filterNot(_._1 == header) :+ (header -> invalidValue)
         }
         authActionFilter.filter(FakeRequest().withHeaders(headers: _*)) shouldFailWith ETMPBadRequest(s"Header is missing or invalid: $header")
       }

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/TestOrgDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/TestOrgDataFixture.scala
@@ -37,12 +37,14 @@ trait TestOrgDataFixture extends Pillar2DataFixture {
   val organisationDetails: TestOrganisation = TestOrganisation(
     orgDetails = orgDetails,
     accountingPeriod = accountingPeriod,
+    accountStatus = AccountStatus(inactive = false), // Default to active
     lastUpdated = java.time.Instant.parse("2024-01-01T00:00:00Z")
   )
 
   val testOrgDetails: TestOrganisation = TestOrganisation(
     orgDetails = orgDetails,
     accountingPeriod = accountingPeriod,
+    accountStatus = AccountStatus(inactive = false), // Default to active
     lastUpdated = Instant.now()
   )
 
@@ -61,6 +63,38 @@ trait TestOrgDataFixture extends Pillar2DataFixture {
   val testOrganisation: TestOrganisationWithId = TestOrganisationWithId(
     pillar2Id = validPlrId,
     organisation = organisationDetails
+  )
+
+  // BTN Status Test Organisations
+  
+  /** Organisation with BTN flag active (inactive = true) - should return error 003 */
+  val organisationWithActiveBtnFlag: TestOrganisationWithId = TestOrganisationWithId(
+    pillar2Id = "XEPLR0000000301", // Different PLR ID for BTN active scenario
+    organisation = testOrgDetails.copy(accountStatus = AccountStatus(inactive = true))
+  )
+
+  /** Organisation with BTN flag inactive (inactive = false) - should allow ORN submissions */
+  val organisationWithInactiveBtnFlag: TestOrganisationWithId = TestOrganisationWithId(
+    pillar2Id = "XEPLR0000000302", // Different PLR ID for BTN inactive scenario
+    organisation = testOrgDetails.copy(accountStatus = AccountStatus(inactive = false))
+  )
+
+  /** Non-domestic organisation with BTN flag active - for testing ORN scenarios */
+  val nonDomesticOrganisationWithActiveBtnFlag: TestOrganisationWithId = TestOrganisationWithId(
+    pillar2Id = "XEPLR0000000303",
+    organisation = testOrgDetails.copy(
+      orgDetails = testOrgDetails.orgDetails.copy(domesticOnly = false),
+      accountStatus = AccountStatus(inactive = true)
+    )
+  )
+
+  /** Non-domestic organisation with BTN flag inactive - for testing ORN scenarios */
+  val nonDomesticOrganisationWithInactiveBtnFlag: TestOrganisationWithId = TestOrganisationWithId(
+    pillar2Id = "XEPLR0000000304",
+    organisation = testOrgDetails.copy(
+      orgDetails = testOrgDetails.orgDetails.copy(domesticOnly = false),
+      accountStatus = AccountStatus(inactive = false)
+    )
   )
 
   val configurableRegistrationDate: PLens[TestOrganisationWithId, TestOrganisationWithId, LocalDate, LocalDate] =

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/TestOrgDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/TestOrgDataFixture.scala
@@ -37,14 +37,14 @@ trait TestOrgDataFixture extends Pillar2DataFixture {
   val organisationDetails: TestOrganisation = TestOrganisation(
     orgDetails = orgDetails,
     accountingPeriod = accountingPeriod,
-    accountStatus = AccountStatus(inactive = false), // Default to active
+    accountStatus = AccountStatus(inactive = false),
     lastUpdated = java.time.Instant.parse("2024-01-01T00:00:00Z")
   )
 
   val testOrgDetails: TestOrganisation = TestOrganisation(
     orgDetails = orgDetails,
     accountingPeriod = accountingPeriod,
-    accountStatus = AccountStatus(inactive = false), // Default to active
+    accountStatus = AccountStatus(inactive = false),
     lastUpdated = Instant.now()
   )
 
@@ -65,21 +65,16 @@ trait TestOrgDataFixture extends Pillar2DataFixture {
     organisation = organisationDetails
   )
 
-  // BTN Status Test Organisations
-  
-  /** Organisation with BTN flag active (inactive = true) - should return error 003 */
   val organisationWithActiveBtnFlag: TestOrganisationWithId = TestOrganisationWithId(
-    pillar2Id = "XEPLR0000000301", // Different PLR ID for BTN active scenario
+    pillar2Id = "XEPLR0000000301",
     organisation = testOrgDetails.copy(accountStatus = AccountStatus(inactive = true))
   )
 
-  /** Organisation with BTN flag inactive (inactive = false) - should allow ORN submissions */
   val organisationWithInactiveBtnFlag: TestOrganisationWithId = TestOrganisationWithId(
-    pillar2Id = "XEPLR0000000302", // Different PLR ID for BTN inactive scenario
+    pillar2Id = "XEPLR0000000302",
     organisation = testOrgDetails.copy(accountStatus = AccountStatus(inactive = false))
   )
 
-  /** Non-domestic organisation with BTN flag active - for testing ORN scenarios */
   val nonDomesticOrganisationWithActiveBtnFlag: TestOrganisationWithId = TestOrganisationWithId(
     pillar2Id = "XEPLR0000000303",
     organisation = testOrgDetails.copy(
@@ -88,7 +83,6 @@ trait TestOrgDataFixture extends Pillar2DataFixture {
     )
   )
 
-  /** Non-domestic organisation with BTN flag inactive - for testing ORN scenarios */
   val nonDomesticOrganisationWithInactiveBtnFlag: TestOrganisationWithId = TestOrganisationWithId(
     pillar2Id = "XEPLR0000000304",
     organisation = testOrgDetails.copy(

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/organisation/OrganisationDetailsSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/organisation/OrganisationDetailsSpec.scala
@@ -93,6 +93,7 @@ class OrganisationDetailsSpec extends AnyWordSpec with Matchers {
     val organisationDetails = TestOrganisation(
       orgDetails = orgDetails,
       accountingPeriod = accountingPeriod,
+      accountStatus = AccountStatus(inactive = false),
       lastUpdated = fixedInstant
     )
 
@@ -114,6 +115,9 @@ class OrganisationDetailsSpec extends AnyWordSpec with Matchers {
           "accountingPeriod": {
             "startDate": "2024-01-01",
             "endDate": "2024-12-31"
+          },
+          "accountStatus": {
+            "inactive": false
           },
           "lastUpdated": {
             "$date": {

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNBtnValidationSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNBtnValidationSpec.scala
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2externalteststub.models.orn
+
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mockito.when
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.pillar2externalteststub.helpers.{ORNDataFixture, TestOrgDataFixture}
+import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.RequestCouldNotBeProcessed
+import uk.gov.hmrc.pillar2externalteststub.validation.syntax._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class ORNBtnValidationSpec 
+    extends AnyWordSpec 
+    with Matchers 
+    with MockitoSugar 
+    with ScalaFutures 
+    with ORNDataFixture 
+    with TestOrgDataFixture {
+
+  "BTN Status Validation" should {
+
+    "Scenario 1: ORN create with BTN flag active (inactive = true)" should {
+      "return error 003 'Request could not be processed'" in {
+        // Given: Organisation with BTN flag active
+        when(mockOrgService.getOrganisation(organisationWithActiveBtnFlag.pillar2Id))
+          .thenReturn(Future.successful(organisationWithActiveBtnFlag))
+        when(mockOrgService.isBtnFlagActive(organisationWithActiveBtnFlag.pillar2Id))
+          .thenReturn(Future.successful(true))
+
+        // When: Validating ORN request
+        val result = ORNValidator.ornValidator(organisationWithActiveBtnFlag.pillar2Id).flatMap { validator =>
+          Future.successful(validORNRequest.validate(validator))
+        }
+
+        // Then: Should return error 003
+        whenReady(result) { validationResult =>
+          validationResult.isInvalid mustBe true
+          validationResult.fold(
+            errors => {
+              errors.head mustBe a[ORNValidationError]
+              val error = errors.head.asInstanceOf[ORNValidationError]
+              error.error mustBe RequestCouldNotBeProcessed
+              error.errorCode mustBe "003"
+              error.errorMessage mustBe "Request could not be processed"
+            },
+            _ => fail("Expected validation to fail")
+          )
+        }
+      }
+    }
+
+    "Scenario 2: ORN amend with BTN flag active (inactive = true)" should {
+      "return error 003 'Request could not be processed'" in {
+        // Given: Organisation with BTN flag active
+        when(mockOrgService.getOrganisation(organisationWithActiveBtnFlag.pillar2Id))
+          .thenReturn(Future.successful(organisationWithActiveBtnFlag))
+        when(mockOrgService.isBtnFlagActive(organisationWithActiveBtnFlag.pillar2Id))
+          .thenReturn(Future.successful(true))
+
+        // When: Validating ORN amendment request
+        val result = ORNValidator.ornValidator(organisationWithActiveBtnFlag.pillar2Id).flatMap { validator =>
+          Future.successful(validORNRequest.validate(validator))
+        }
+
+        // Then: Should return error 003 (same validation applies for both create and amend)
+        whenReady(result) { validationResult =>
+          validationResult.isInvalid mustBe true
+          validationResult.fold(
+            errors => {
+              errors.head mustBe a[ORNValidationError]
+              val error = errors.head.asInstanceOf[ORNValidationError]
+              error.error mustBe RequestCouldNotBeProcessed
+              error.errorCode mustBe "003"
+            },
+            _ => fail("Expected validation to fail")
+          )
+        }
+      }
+    }
+
+    "Scenario 3: ORN create with BTN flag inactive (inactive = false)" should {
+      "return success and allow submission" in {
+        // Given: Non-domestic organisation with BTN flag inactive
+        when(mockOrgService.getOrganisation(nonDomesticOrganisationWithInactiveBtnFlag.pillar2Id))
+          .thenReturn(Future.successful(nonDomesticOrganisationWithInactiveBtnFlag))
+        when(mockOrgService.isBtnFlagActive(nonDomesticOrganisationWithInactiveBtnFlag.pillar2Id))
+          .thenReturn(Future.successful(false))
+
+        // When: Validating ORN request
+        val result = ORNValidator.ornValidator(nonDomesticOrganisationWithInactiveBtnFlag.pillar2Id).flatMap { validator =>
+          Future.successful(validORNRequest.validate(validator))
+        }
+
+        // Then: Should pass validation (return Valid)
+        whenReady(result) { validationResult =>
+          validationResult.isValid mustBe true
+        }
+      }
+    }
+
+    "Scenario 4: ORN amend with BTN flag inactive (inactive = false)" should {
+      "return success and allow amendment" in {
+        // Given: Non-domestic organisation with BTN flag inactive
+        when(mockOrgService.getOrganisation(nonDomesticOrganisationWithInactiveBtnFlag.pillar2Id))
+          .thenReturn(Future.successful(nonDomesticOrganisationWithInactiveBtnFlag))
+        when(mockOrgService.isBtnFlagActive(nonDomesticOrganisationWithInactiveBtnFlag.pillar2Id))
+          .thenReturn(Future.successful(false))
+
+        // When: Validating ORN amendment request
+        val result = ORNValidator.ornValidator(nonDomesticOrganisationWithInactiveBtnFlag.pillar2Id).flatMap { validator =>
+          Future.successful(validORNRequest.validate(validator))
+        }
+
+        // Then: Should pass validation (return Valid)
+        whenReady(result) { validationResult =>
+          validationResult.isValid mustBe true
+        }
+      }
+    }
+
+    "BTN status rule in isolation" should {
+      "return error when BTN flag is active" in {
+        // Given: BTN flag is active
+        when(mockOrgService.isBtnFlagActive(anyString()))
+          .thenReturn(Future.successful(true))
+
+        // When: Applying BTN status rule
+        val result = ORNValidationRules.btnStatusRule("test-pillar2-id").map { rule =>
+          validORNRequest.validate(rule)
+        }
+
+        // Then: Should return error 003
+        whenReady(result) { validationResult =>
+          validationResult.isInvalid mustBe true
+          validationResult.fold(
+            errors => {
+              val error = errors.head.asInstanceOf[ORNValidationError]
+              error.error mustBe RequestCouldNotBeProcessed
+            },
+            _ => fail("Expected validation to fail")
+          )
+        }
+      }
+
+      "return success when BTN flag is inactive" in {
+        // Given: BTN flag is inactive
+        when(mockOrgService.isBtnFlagActive(anyString()))
+          .thenReturn(Future.successful(false))
+
+        // When: Applying BTN status rule
+        val result = ORNValidationRules.btnStatusRule("test-pillar2-id").map { rule =>
+          validORNRequest.validate(rule)
+        }
+
+        // Then: Should pass validation
+        whenReady(result) { validationResult =>
+          validationResult.isValid mustBe true
+        }
+      }
+    }
+  }
+} 

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNBtnValidationSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/orn/ORNBtnValidationSpec.scala
@@ -38,7 +38,7 @@ class ORNBtnValidationSpec extends AnyWordSpec with Matchers with MockitoSugar w
         when(mockOrgService.getOrganisation(organisationWithActiveBtnFlag.pillar2Id))
           .thenReturn(Future.successful(organisationWithActiveBtnFlag))
 
-        val result = ORNValidator.ornValidator(organisationWithActiveBtnFlag.pillar2Id).flatMap { validator =>
+        val result = ORNValidator.ornValidator(organisationWithActiveBtnFlag.pillar2Id)(mockOrgService, global).flatMap { validator =>
           Future.successful(validORNRequest.validate(validator))
         }
 
@@ -64,7 +64,7 @@ class ORNBtnValidationSpec extends AnyWordSpec with Matchers with MockitoSugar w
         when(mockOrgService.getOrganisation(organisationWithActiveBtnFlag.pillar2Id))
           .thenReturn(Future.successful(organisationWithActiveBtnFlag))
 
-        val result = ORNValidator.ornValidator(organisationWithActiveBtnFlag.pillar2Id).flatMap { validator =>
+        val result = ORNValidator.ornValidator(organisationWithActiveBtnFlag.pillar2Id)(mockOrgService, global).flatMap { validator =>
           Future.successful(validORNRequest.validate(validator))
         }
 
@@ -88,7 +88,7 @@ class ORNBtnValidationSpec extends AnyWordSpec with Matchers with MockitoSugar w
         when(mockOrgService.getOrganisation(nonDomesticOrganisationWithInactiveBtnFlag.pillar2Id))
           .thenReturn(Future.successful(nonDomesticOrganisationWithInactiveBtnFlag))
 
-        val result = ORNValidator.ornValidator(nonDomesticOrganisationWithInactiveBtnFlag.pillar2Id).flatMap { validator =>
+        val result = ORNValidator.ornValidator(nonDomesticOrganisationWithInactiveBtnFlag.pillar2Id)(mockOrgService, global).flatMap { validator =>
           Future.successful(validORNRequest.validate(validator))
         }
 
@@ -104,7 +104,7 @@ class ORNBtnValidationSpec extends AnyWordSpec with Matchers with MockitoSugar w
         when(mockOrgService.getOrganisation(nonDomesticOrganisationWithInactiveBtnFlag.pillar2Id))
           .thenReturn(Future.successful(nonDomesticOrganisationWithInactiveBtnFlag))
 
-        val result = ORNValidator.ornValidator(nonDomesticOrganisationWithInactiveBtnFlag.pillar2Id).flatMap { validator =>
+        val result = ORNValidator.ornValidator(nonDomesticOrganisationWithInactiveBtnFlag.pillar2Id)(mockOrgService, global).flatMap { validator =>
           Future.successful(validORNRequest.validate(validator))
         }
 

--- a/test/uk/gov/hmrc/pillar2externalteststub/repositories/OrganisationRepositorySpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/repositories/OrganisationRepositorySpec.scala
@@ -67,6 +67,7 @@ class OrganisationRepositorySpec
   private val organisation = TestOrganisation(
     orgDetails = orgDetails,
     accountingPeriod = accountingPeriod,
+    accountStatus = AccountStatus(inactive = false),
     lastUpdated = java.time.Instant.parse("2024-01-01T00:00:00Z")
   )
 

--- a/test/uk/gov/hmrc/pillar2externalteststub/services/BTNServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/services/BTNServiceSpec.scala
@@ -29,7 +29,6 @@ import uk.gov.hmrc.pillar2externalteststub.helpers.{BTNDataFixture, ObligationsA
 import uk.gov.hmrc.pillar2externalteststub.models.btn.BTNRequest
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.RequestCouldNotBeProcessed
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.TaxObligationAlreadyFulfilled
-import uk.gov.hmrc.pillar2externalteststub.models.organisation.TestOrganisation
 import uk.gov.hmrc.pillar2externalteststub.repositories.{BTNSubmissionRepository, ObligationsAndSubmissionsRepository}
 
 import java.time.LocalDate
@@ -94,8 +93,8 @@ class BTNServiceSpec
           .thenReturn(Future.successful(true))
         when(mockOrgService.getOrganisation(anyString()))
           .thenReturn(Future.successful(domesticOrganisation))
-        when(mockOrgService.updateOrganisation(eqTo(validPlrId), any[TestOrganisation]))
-          .thenReturn(Future.successful(domesticOrganisation))
+        when(mockOrgService.makeOrganisatonInactive(eqTo(validPlrId)))
+          .thenReturn(Future.successful(()))
 
         val result = service.submitBTN(validPlrId, validBTNRequest)
 
@@ -112,8 +111,8 @@ class BTNServiceSpec
           .thenReturn(Future.successful(true))
         when(mockOrgService.getOrganisation(anyString()))
           .thenReturn(Future.successful(domesticOrganisation))
-        when(mockOrgService.updateOrganisation(eqTo(validPlrId), any[TestOrganisation]))
-          .thenReturn(Future.successful(domesticOrganisation))
+        when(mockOrgService.makeOrganisatonInactive(eqTo(validPlrId)))
+          .thenReturn(Future.successful(()))
 
         val result = service.submitBTN(validPlrId, validBTNRequest)
 
@@ -130,8 +129,8 @@ class BTNServiceSpec
           .thenReturn(Future.successful(true))
         when(mockOrgService.getOrganisation(anyString()))
           .thenReturn(Future.successful(domesticOrganisation))
-        when(mockOrgService.updateOrganisation(eqTo(validPlrId), any[TestOrganisation]))
-          .thenReturn(Future.successful(domesticOrganisation))
+        when(mockOrgService.makeOrganisatonInactive(eqTo(validPlrId)))
+          .thenReturn(Future.successful(()))
 
         val result = service.submitBTN(validPlrId, validBTNRequest)
 
@@ -148,8 +147,8 @@ class BTNServiceSpec
           .thenReturn(Future.successful(true))
         when(mockOrgService.getOrganisation(anyString()))
           .thenReturn(Future.successful(domesticOrganisation))
-        when(mockOrgService.updateOrganisation(eqTo(validPlrId), any[TestOrganisation]))
-          .thenReturn(Future.successful(domesticOrganisation))
+        when(mockOrgService.makeOrganisatonInactive(eqTo(validPlrId)))
+          .thenReturn(Future.successful(()))
 
         val result = service.submitBTN(validPlrId, validBTNRequest)
 

--- a/test/uk/gov/hmrc/pillar2externalteststub/services/BTNServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/services/BTNServiceSpec.scala
@@ -29,6 +29,7 @@ import uk.gov.hmrc.pillar2externalteststub.helpers.{BTNDataFixture, ObligationsA
 import uk.gov.hmrc.pillar2externalteststub.models.btn.BTNRequest
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.RequestCouldNotBeProcessed
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.TaxObligationAlreadyFulfilled
+import uk.gov.hmrc.pillar2externalteststub.models.organisation.TestOrganisation
 import uk.gov.hmrc.pillar2externalteststub.repositories.{BTNSubmissionRepository, ObligationsAndSubmissionsRepository}
 
 import java.time.LocalDate
@@ -76,7 +77,7 @@ class BTNServiceSpec
           .thenReturn(Future.successful(domesticOrganisation))
         val invalidRequest = validBTNRequest.copy(
           accountingPeriodFrom = LocalDate.of(2023, 1, 1),
-          accountingPeriodTo = LocalDate.of(2022, 12, 31) // End date before start date
+          accountingPeriodTo = LocalDate.of(2022, 12, 31)
         )
 
         val result = service.submitBTN(validPlrId, invalidRequest)
@@ -93,12 +94,13 @@ class BTNServiceSpec
           .thenReturn(Future.successful(true))
         when(mockOrgService.getOrganisation(anyString()))
           .thenReturn(Future.successful(domesticOrganisation))
+        when(mockOrgService.updateOrganisation(eqTo(validPlrId), any[TestOrganisation]))
+          .thenReturn(Future.successful(domesticOrganisation))
 
         val result = service.submitBTN(validPlrId, validBTNRequest)
 
         result.futureValue mustBe true
         verify(mockBtnRepository).insert(validPlrId, validBTNRequest)
-        verify(mockOasRepository).insert(eqTo(validBTNRequest), eqTo(validPlrId), any[ObjectId](), eqTo(false))
       }
 
       "successfully submit a BTN when there is a UKTR submission for the period but no BTN" in {
@@ -110,12 +112,13 @@ class BTNServiceSpec
           .thenReturn(Future.successful(true))
         when(mockOrgService.getOrganisation(anyString()))
           .thenReturn(Future.successful(domesticOrganisation))
+        when(mockOrgService.updateOrganisation(eqTo(validPlrId), any[TestOrganisation]))
+          .thenReturn(Future.successful(domesticOrganisation))
 
         val result = service.submitBTN(validPlrId, validBTNRequest)
 
         result.futureValue mustBe true
         verify(mockBtnRepository).insert(validPlrId, validBTNRequest)
-        verify(mockOasRepository).insert(eqTo(validBTNRequest), eqTo(validPlrId), any[ObjectId](), eqTo(false))
       }
 
       "successfully submit a BTN when there is an older BTN submission for the period that is not the most recent submission" in {
@@ -127,12 +130,13 @@ class BTNServiceSpec
           .thenReturn(Future.successful(true))
         when(mockOrgService.getOrganisation(anyString()))
           .thenReturn(Future.successful(domesticOrganisation))
+        when(mockOrgService.updateOrganisation(eqTo(validPlrId), any[TestOrganisation]))
+          .thenReturn(Future.successful(domesticOrganisation))
 
         val result = service.submitBTN(validPlrId, validBTNRequest)
 
         result.futureValue mustBe true
         verify(mockBtnRepository).insert(validPlrId, validBTNRequest)
-        verify(mockOasRepository).insert(eqTo(validBTNRequest), eqTo(validPlrId), any[ObjectId](), eqTo(false))
       }
 
       "successfully submit a BTN when there is a BTN submission for a different period" in {
@@ -144,12 +148,13 @@ class BTNServiceSpec
           .thenReturn(Future.successful(true))
         when(mockOrgService.getOrganisation(anyString()))
           .thenReturn(Future.successful(domesticOrganisation))
+        when(mockOrgService.updateOrganisation(eqTo(validPlrId), any[TestOrganisation]))
+          .thenReturn(Future.successful(domesticOrganisation))
 
         val result = service.submitBTN(validPlrId, validBTNRequest)
 
         result.futureValue mustBe true
         verify(mockBtnRepository).insert(validPlrId, validBTNRequest)
-        verify(mockOasRepository).insert(eqTo(validBTNRequest), eqTo(validPlrId), any[ObjectId](), eqTo(false))
       }
     }
   }

--- a/test/uk/gov/hmrc/pillar2externalteststub/services/UKTRServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/services/UKTRServiceSpec.scala
@@ -26,9 +26,9 @@ import uk.gov.hmrc.pillar2externalteststub.helpers.Pillar2Helper.{AMENDMENT_WIND
 import uk.gov.hmrc.pillar2externalteststub.helpers.{ObligationsAndSubmissionsDataFixture, TestOrgDataFixture, UKTRDataFixture}
 import uk.gov.hmrc.pillar2externalteststub.models.common.BaseSubmission
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError._
+import uk.gov.hmrc.pillar2externalteststub.models.organisation.TestOrganisation
 import uk.gov.hmrc.pillar2externalteststub.models.uktr._
 import uk.gov.hmrc.pillar2externalteststub.models.uktr.mongo.UKTRMongoSubmission
-import uk.gov.hmrc.pillar2externalteststub.models.organisation.TestOrganisation
 import uk.gov.hmrc.pillar2externalteststub.repositories.{ObligationsAndSubmissionsRepository, UKTRSubmissionRepository}
 
 import java.time.{Instant, LocalDate}

--- a/test/uk/gov/hmrc/pillar2externalteststub/services/UKTRServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/services/UKTRServiceSpec.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.pillar2externalteststub.models.common.BaseSubmission
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError._
 import uk.gov.hmrc.pillar2externalteststub.models.uktr._
 import uk.gov.hmrc.pillar2externalteststub.models.uktr.mongo.UKTRMongoSubmission
+import uk.gov.hmrc.pillar2externalteststub.models.organisation.TestOrganisation
 import uk.gov.hmrc.pillar2externalteststub.repositories.{ObligationsAndSubmissionsRepository, UKTRSubmissionRepository}
 
 import java.time.{Instant, LocalDate}
@@ -51,6 +52,8 @@ class UKTRServiceSpec
     "when submitting a return" - {
       "should successfully submit a liability return" in {
         when(mockOrgService.getOrganisation(eqTo(validPlrId)))
+          .thenReturn(Future.successful(nonDomesticOrganisation))
+        when(mockOrgService.updateOrganisation(eqTo(validPlrId), any[TestOrganisation]))
           .thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.findByPillar2Id(eqTo(validPlrId)))
           .thenReturn(Future.successful(None))

--- a/test/uk/gov/hmrc/pillar2externalteststub/services/UKTRServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/services/UKTRServiceSpec.scala
@@ -26,7 +26,6 @@ import uk.gov.hmrc.pillar2externalteststub.helpers.Pillar2Helper.{AMENDMENT_WIND
 import uk.gov.hmrc.pillar2externalteststub.helpers.{ObligationsAndSubmissionsDataFixture, TestOrgDataFixture, UKTRDataFixture}
 import uk.gov.hmrc.pillar2externalteststub.models.common.BaseSubmission
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError._
-import uk.gov.hmrc.pillar2externalteststub.models.organisation.TestOrganisation
 import uk.gov.hmrc.pillar2externalteststub.models.uktr._
 import uk.gov.hmrc.pillar2externalteststub.models.uktr.mongo.UKTRMongoSubmission
 import uk.gov.hmrc.pillar2externalteststub.repositories.{ObligationsAndSubmissionsRepository, UKTRSubmissionRepository}
@@ -53,14 +52,14 @@ class UKTRServiceSpec
       "should successfully submit a liability return" in {
         when(mockOrgService.getOrganisation(eqTo(validPlrId)))
           .thenReturn(Future.successful(nonDomesticOrganisation))
-        when(mockOrgService.updateOrganisation(eqTo(validPlrId), any[TestOrganisation]))
-          .thenReturn(Future.successful(nonDomesticOrganisation))
         when(mockUKTRRepository.findByPillar2Id(eqTo(validPlrId)))
           .thenReturn(Future.successful(None))
         when(mockUKTRRepository.insert(any[UKTRLiabilityReturn], eqTo(validPlrId), any[Option[String]]))
           .thenReturn(Future.successful(new ObjectId()))
         when(mockOASRepository.insert(any[BaseSubmission], eqTo(validPlrId), any[ObjectId], eqTo(false)))
           .thenReturn(Future.successful(true))
+        when(mockOrgService.makeOrganisatonActive(eqTo(validPlrId)))
+          .thenReturn(Future.successful(()))
 
         val result = Await.result(service.submitUKTR(validPlrId, liabilitySubmission), 5.seconds)
         result match {
@@ -81,6 +80,8 @@ class UKTRServiceSpec
           .thenReturn(Future.successful(new ObjectId()))
         when(mockOASRepository.insert(any[BaseSubmission], eqTo(validPlrId), any[ObjectId], eqTo(false)))
           .thenReturn(Future.successful(true))
+        when(mockOrgService.makeOrganisatonActive(eqTo(validPlrId)))
+          .thenReturn(Future.successful(()))
 
         val result = Await.result(service.submitUKTR(validPlrId, nilSubmission), 5.seconds)
         result match {
@@ -114,6 +115,8 @@ class UKTRServiceSpec
           .thenReturn(Future.successful((new ObjectId(), Some(chargeReference))))
         when(mockOASRepository.insert(any[BaseSubmission], eqTo(validPlrId), any[ObjectId], eqTo(true)))
           .thenReturn(Future.successful(true))
+        when(mockOrgService.makeOrganisatonActive(eqTo(validPlrId)))
+          .thenReturn(Future.successful(()))
 
         val result = Await.result(service.amendUKTR(validPlrId, liabilitySubmission), 5.seconds)
         result match {
@@ -144,6 +147,8 @@ class UKTRServiceSpec
           .thenReturn(Future.successful((new ObjectId(), Some("existing-ref"))))
         when(mockOASRepository.insert(any[BaseSubmission], eqTo(validPlrId), any[ObjectId], eqTo(true)))
           .thenReturn(Future.successful(true))
+        when(mockOrgService.makeOrganisatonActive(eqTo(validPlrId)))
+          .thenReturn(Future.successful(()))
 
         val result = Await.result(service.amendUKTR(validPlrId, nilSubmission), 5.seconds)
         result match {
@@ -304,6 +309,8 @@ class UKTRServiceSpec
             .thenReturn(Future.successful(new ObjectId()))
           when(mockOASRepository.insert(any[BaseSubmission], eqTo(validPlrId), any[ObjectId], eqTo(false)))
             .thenReturn(Future.successful(true))
+          when(mockOrgService.makeOrganisatonActive(eqTo(validPlrId)))
+            .thenReturn(Future.successful(()))
 
           val liabilityReturn = liabilitySubmission.asInstanceOf[UKTRLiabilityReturn]
           val validSubmission = liabilityReturn.copy(
@@ -338,6 +345,8 @@ class UKTRServiceSpec
             .thenReturn(Future.successful((new ObjectId(), Some(chargeReference))))
           when(mockOASRepository.insert(any[BaseSubmission], eqTo(validPlrId), any[ObjectId], eqTo(true)))
             .thenReturn(Future.successful(true))
+          when(mockOrgService.makeOrganisatonActive(eqTo(validPlrId)))
+            .thenReturn(Future.successful(()))
 
           val liabilityReturn = liabilitySubmission.asInstanceOf[UKTRLiabilityReturn]
           val validSubmission = liabilityReturn.copy(


### PR DESCRIPTION
Implements BTN (Below Threshold Notification) flag status validation for Overseas Return Notification (ORN) submissions as per EPID 1457 requirements. The validation checks the organisation's account status and returns error code 003 when the BTN flag is active (inactive = true).