### PR TITLE
NOJIRA - Remove auth filter from GIR endpoint

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/GIRController.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/GIRController.scala
@@ -36,7 +36,7 @@ class GIRController @Inject() (
     extends BackendController(cc)
     with Logging {
 
-  def submitGIR: Action[JsValue] = (Action(parse.json) andThen authFilter).async { implicit request =>
+  def submitGIR: Action[JsValue] = (Action(parse.json)).async { implicit request =>
     validatePillar2Id(request.headers.get("X-Pillar2-Id"))
       .flatMap { pillar2Id =>
         request.body


### PR DESCRIPTION
The submitGIR endpoint was returning a 500 error because it was incorrectly performing an authentication check. The calling service (submission-api) does not provide the headers required for this check.
This authentication is unnecessary because the endpoint is an internal test stub, not a real endpoint that will be exposed by ETMP.
This change removes the authentication filter from GIRController to resolve the error, making its behavior consistent with other test-only endpoints in this service.