### PR TITLE
PIL-2049: Add optional underEnquiry field to testOrg accounting periods

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsController.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/ObligationsAndSubmissionsController.scala
@@ -81,6 +81,7 @@ class ObligationsAndSubmissionsController @Inject() (
           testOrg.organisation.accountingPeriod.startDate,
           testOrg.organisation.accountingPeriod.endDate,
           testOrg.organisation.orgDetails.registrationDate,
+          testOrg.organisation.accountingPeriod.underEnquiry,
           Seq.empty
         )
       )
@@ -91,6 +92,7 @@ class ObligationsAndSubmissionsController @Inject() (
           accountingPeriod.startDate,
           accountingPeriod.endDate,
           testOrg.organisation.orgDetails.registrationDate,
+          testOrg.organisation.accountingPeriod.underEnquiry,
           submissions.map(toSubmission)
         )
       }.toSeq
@@ -116,10 +118,11 @@ class ObligationsAndSubmissionsController @Inject() (
     )
 
   private def createAccountingPeriodDetails(
-    startDate:   LocalDate,
-    endDate:     LocalDate,
-    regDate:     LocalDate,
-    submissions: Seq[Submission]
+    startDate:    LocalDate,
+    endDate:      LocalDate,
+    regDate:      LocalDate,
+    underEnquiry: Option[Boolean],
+    submissions:  Seq[Submission]
   ): AccountingPeriodDetails = {
     val dueDate  = regDate.plusMonths(FIRST_AP_DUE_DATE_FROM_REGISTRATION_MONTHS)
     val canAmend = !LocalDate.now().isAfter(dueDate.plusMonths(AMENDMENT_WINDOW_MONTHS))
@@ -168,7 +171,7 @@ class ObligationsAndSubmissionsController @Inject() (
       startDate = startDate,
       endDate = endDate,
       dueDate = dueDate,
-      underEnquiry = false,
+      underEnquiry = underEnquiry.fold(false)(identity),
       obligations = obligations
     )
   }

--- a/app/uk/gov/hmrc/pillar2externalteststub/controllers/StubErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/controllers/StubErrorHandler.scala
@@ -51,7 +51,7 @@ class StubErrorHandler extends HttpErrorHandler with Logging {
         val ret = e match {
           case IdMissingOrInvalid | RequestCouldNotBeProcessed | NoFormBundleFound | NoActiveSubscription | NoDataFound |
               TaxObligationAlreadyFulfilled | InvalidReturn | InvalidDTTElection | InvalidUTPRElection | InvalidTotalLiability |
-              InvalidTotalLiabilityIIR | InvalidTotalLiabilityDTT | InvalidTotalLiabilityUTPR =>
+              InvalidTotalLiabilityIIR | InvalidTotalLiabilityDTT | InvalidTotalLiabilityUTPR | AccountingPeriodUnderEnquiry =>
             Results.UnprocessableEntity(Json.toJson(ETMPFailureResponse(ETMPDetailedError(e.code, e.message))))
           case ETMPInternalServerError => Results.InternalServerError(Json.toJson(ETMPErrorResponse(ETMPSimpleError(e))))
         }

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/error/ETMPError.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/error/ETMPError.scala
@@ -89,6 +89,11 @@ object ETMPError {
     override val message: String = "Invalid Total Liability UTPR"
   }
 
+  case object AccountingPeriodUnderEnquiry extends ETMPError {
+    override val code:    String = "100"
+    override val message: String = "Accounting period under enquiry"
+  }
+
   case object ETMPInternalServerError extends ETMPError {
     override val code:    String         = "500"
     override val message: String         = "Internal server error"

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/organisation/TestOrganisation.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/organisation/TestOrganisation.scala
@@ -28,10 +28,7 @@ case class OrgDetails(
   registrationDate: LocalDate
 )
 
-case class AccountingPeriod(
-  startDate: LocalDate,
-  endDate:   LocalDate
-)
+case class AccountingPeriod(startDate: LocalDate, endDate: LocalDate, underEnquiry: Option[Boolean])
 
 case class AccountStatus(
   inactive: Boolean
@@ -55,7 +52,18 @@ case class TestOrganisation(
 case class TestOrganisationWithId(
   pillar2Id:    String,
   organisation: TestOrganisation
-)
+) {
+  def withUnderEnquiry(org: TestOrganisationWithId): TestOrganisationWithId =
+    TestOrganisationWithId(
+      pillar2Id,
+      org.organisation
+        .copy(
+          accountingPeriod = org.organisation.accountingPeriod.copy(
+            underEnquiry = org.organisation.accountingPeriod.underEnquiry.fold(Some(false))(Some(_))
+          )
+        )
+    )
+}
 
 object OrgDetails {
   implicit val format: Format[OrgDetails] = Json.format[OrgDetails]

--- a/app/uk/gov/hmrc/pillar2externalteststub/services/OrganisationService.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/services/OrganisationService.scala
@@ -34,7 +34,7 @@ class OrganisationService @Inject() (
       case Some(_) =>
         Future.failed(OrganisationAlreadyExists(pillar2Id))
       case None =>
-        repository.insert(organisationWithId).map(_ => organisationWithId)
+        repository.insert(organisationWithId).map(_ => organisationWithId.withUnderEnquiry(organisationWithId))
     }
   }
 
@@ -42,7 +42,7 @@ class OrganisationService @Inject() (
     repository
       .findByPillar2Id(pillar2Id)
       .flatMap {
-        case Some(org) => Future.successful(org)
+        case Some(org) => Future.successful(org.withUnderEnquiry(org))
         case None      => Future.failed(OrganisationNotFound(pillar2Id))
       }
 

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/OrganisationISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/OrganisationISpec.scala
@@ -16,23 +16,22 @@
 
 package uk.gov.hmrc.pillar2externalteststub
 
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import org.scalatest.BeforeAndAfterEach
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsValue, Json}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
-import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.HttpReads.Implicits._
-import uk.gov.hmrc.http.StringContextOps
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import uk.gov.hmrc.pillar2externalteststub.helpers.TestOrgDataFixture
 import uk.gov.hmrc.pillar2externalteststub.models.organisation._
-import uk.gov.hmrc.pillar2externalteststub.repositories.OrganisationRepository
 import uk.gov.hmrc.pillar2externalteststub.models.response.StubErrorResponse
+import uk.gov.hmrc.pillar2externalteststub.repositories.OrganisationRepository
 
 import java.time.LocalDate
 import scala.concurrent.ExecutionContext

--- a/it/test/uk/gov/hmrc/pillar2externalteststub/OrganisationISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2externalteststub/OrganisationISpec.scala
@@ -64,7 +64,8 @@ class OrganisationISpec
 
   private val testAccountingPeriod = AccountingPeriod(
     startDate = LocalDate.of(2024, 1, 1),
-    endDate = LocalDate.of(2024, 12, 31)
+    endDate = LocalDate.of(2024, 12, 31),
+    None
   )
 
   private val testOrganisationRequest = TestOrganisationRequest(

--- a/test/uk/gov/hmrc/pillar2externalteststub/controllers/StubErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/controllers/StubErrorHandlerSpec.scala
@@ -199,6 +199,14 @@ class StubErrorHandlerSpec extends AnyWordSpec with Matchers {
       (json \ "errors" \ "text").as[String] shouldBe "Invalid Total Liability UTPR"
     }
 
+    "handle AccountingPeriodUnderEnquiry error" in {
+      val result = errorHandler.onServerError(dummyRequest, AccountingPeriodUnderEnquiry)
+      status(result) shouldBe UNPROCESSABLE_ENTITY
+      val json = contentAsJson(result)
+      (json \ "errors" \ "code").as[String] shouldBe "100"
+      (json \ "errors" \ "text").as[String] shouldBe "Accounting period under enquiry"
+    }
+
     "handle HIPBadRequest error" in {
       val result = errorHandler.onServerError(dummyRequest, HIPBadRequest("Missing Header"))
       status(result) shouldBe BAD_REQUEST

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/Pillar2DataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/Pillar2DataFixture.scala
@@ -53,6 +53,7 @@ trait Pillar2DataFixture {
 
   val accountingPeriod: AccountingPeriod = AccountingPeriod(
     startDate = LocalDate.of(2024, 1, 1),
-    endDate = LocalDate.of(2024, 12, 31)
+    endDate = LocalDate.of(2024, 12, 31),
+    None
   )
 }

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/TestOrgDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/TestOrgDataFixture.scala
@@ -38,27 +38,28 @@ trait TestOrgDataFixture extends Pillar2DataFixture {
     orgDetails = orgDetails,
     accountingPeriod = accountingPeriod,
     accountStatus = AccountStatus(inactive = false),
-    lastUpdated = java.time.Instant.parse("2024-01-01T00:00:00Z")
-  )
-
-  val testOrgDetails: TestOrganisation = TestOrganisation(
-    orgDetails = orgDetails,
-    accountingPeriod = accountingPeriod,
-    accountStatus = AccountStatus(inactive = false),
-    lastUpdated = Instant.now()
+    lastUpdated = Instant.parse("2024-01-01T00:00:00Z")
   )
 
   val nonDomesticOrganisation: TestOrganisationWithId = TestOrganisationWithId(
     pillar2Id = nonDomesticPlrId,
-    organisation = testOrgDetails
+    organisation = organisationDetails
   )
 
   val domesticOrganisation: TestOrganisationWithId = TestOrganisationWithId(
     pillar2Id = validPlrId,
-    organisation = testOrgDetails.copy(orgDetails = testOrgDetails.orgDetails.copy(domesticOnly = true))
+    organisation = organisationDetails.copy(orgDetails = organisationDetails.orgDetails.copy(domesticOnly = true))
   )
 
   val organisationWithId: TestOrganisationWithId = organisationDetails.withPillar2Id(validPlrId)
+
+  val orgWithApUnderEnquiry: TestOrganisationWithId = organisationWithId.copy(
+    organisation = organisationWithId.organisation.copy(
+      accountingPeriod = organisationWithId.organisation.accountingPeriod.copy(
+        underEnquiry = Some(true)
+      )
+    )
+  )
 
   val testOrganisation: TestOrganisationWithId = TestOrganisationWithId(
     pillar2Id = validPlrId,
@@ -67,26 +68,26 @@ trait TestOrgDataFixture extends Pillar2DataFixture {
 
   val organisationWithActiveBtnFlag: TestOrganisationWithId = TestOrganisationWithId(
     pillar2Id = "XEPLR0000000301",
-    organisation = testOrgDetails.copy(accountStatus = AccountStatus(inactive = true))
+    organisation = organisationDetails.copy(accountStatus = AccountStatus(inactive = true))
   )
 
   val organisationWithInactiveBtnFlag: TestOrganisationWithId = TestOrganisationWithId(
     pillar2Id = "XEPLR0000000302",
-    organisation = testOrgDetails.copy(accountStatus = AccountStatus(inactive = false))
+    organisation = organisationDetails.copy(accountStatus = AccountStatus(inactive = false))
   )
 
   val nonDomesticOrganisationWithActiveBtnFlag: TestOrganisationWithId = TestOrganisationWithId(
     pillar2Id = "XEPLR0000000303",
-    organisation = testOrgDetails.copy(
-      orgDetails = testOrgDetails.orgDetails.copy(domesticOnly = false),
+    organisation = organisationDetails.copy(
+      orgDetails = organisationDetails.orgDetails.copy(domesticOnly = false),
       accountStatus = AccountStatus(inactive = true)
     )
   )
 
   val nonDomesticOrganisationWithInactiveBtnFlag: TestOrganisationWithId = TestOrganisationWithId(
     pillar2Id = "XEPLR0000000304",
-    organisation = testOrgDetails.copy(
-      orgDetails = testOrgDetails.orgDetails.copy(domesticOnly = false),
+    organisation = organisationDetails.copy(
+      orgDetails = organisationDetails.orgDetails.copy(domesticOnly = false),
       accountStatus = AccountStatus(inactive = false)
     )
   )

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/organisation/OrganisationDetailsSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/organisation/OrganisationDetailsSpec.scala
@@ -56,12 +56,14 @@ class OrganisationDetailsSpec extends AnyWordSpec with Matchers {
     "serialize to JSON correctly" in {
       val period = AccountingPeriod(
         startDate = LocalDate.of(2024, 1, 1),
-        endDate = LocalDate.of(2024, 12, 31)
+        endDate = LocalDate.of(2024, 12, 31),
+        underEnquiry = Some(true)
       )
 
       val json = Json.toJson(period)
       json.toString should include("2024-01-01")
       json.toString should include("2024-12-31")
+      json.toString should include("true")
     }
 
     "deserialize from JSON correctly" in {
@@ -86,7 +88,8 @@ class OrganisationDetailsSpec extends AnyWordSpec with Matchers {
 
     val accountingPeriod = AccountingPeriod(
       startDate = LocalDate.of(2024, 1, 1),
-      endDate = LocalDate.of(2024, 12, 31)
+      endDate = LocalDate.of(2024, 12, 31),
+      underEnquiry = Some(true)
     )
 
     val fixedInstant = Instant.parse("2024-01-01T00:00:00Z")
@@ -102,6 +105,7 @@ class OrganisationDetailsSpec extends AnyWordSpec with Matchers {
       json.toString should include("Test Org")
       json.toString should include("2024-01-01")
       json.toString should include(""""$date":{"$numberLong":"1704067200000"}""")
+      json.toString should include(""""underEnquiry":true""")
     }
 
     "deserialize from JSON correctly" in {
@@ -114,7 +118,8 @@ class OrganisationDetailsSpec extends AnyWordSpec with Matchers {
           },
           "accountingPeriod": {
             "startDate": "2024-01-01",
-            "endDate": "2024-12-31"
+            "endDate": "2024-12-31",
+            "underEnquiry": true
           },
           "accountStatus": {
             "inactive": false
@@ -129,8 +134,9 @@ class OrganisationDetailsSpec extends AnyWordSpec with Matchers {
 
       json.validate[TestOrganisation](TestOrganisation.mongoFormat) shouldBe a[JsSuccess[_]]
       val parsed = json.as[TestOrganisation](TestOrganisation.mongoFormat)
-      parsed.orgDetails.organisationName shouldBe "Test Org"
-      parsed.lastUpdated                 shouldBe fixedInstant
+      parsed.orgDetails.organisationName   shouldBe "Test Org"
+      parsed.lastUpdated                   shouldBe fixedInstant
+      parsed.accountingPeriod.underEnquiry shouldBe Some(true)
     }
 
     "create OrganisationDetailsWithId correctly" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/services/BTNServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/services/BTNServiceSpec.scala
@@ -27,8 +27,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.pillar2externalteststub.helpers.{BTNDataFixture, ObligationsAndSubmissionsDataFixture, TestOrgDataFixture}
 import uk.gov.hmrc.pillar2externalteststub.models.btn.BTNRequest
-import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.RequestCouldNotBeProcessed
-import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.TaxObligationAlreadyFulfilled
+import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError.{AccountingPeriodUnderEnquiry, RequestCouldNotBeProcessed, TaxObligationAlreadyFulfilled}
 import uk.gov.hmrc.pillar2externalteststub.repositories.{BTNSubmissionRepository, ObligationsAndSubmissionsRepository}
 
 import java.time.LocalDate
@@ -82,6 +81,15 @@ class BTNServiceSpec
         val result = service.submitBTN(validPlrId, invalidRequest)
 
         result shouldFailWith RequestCouldNotBeProcessed
+      }
+
+      "fail with AccountingPeriodUnderEnquiry when an accounting period is under enquiry" in {
+        when(mockOrgService.getOrganisation(anyString()))
+          .thenReturn(Future.successful(orgWithApUnderEnquiry))
+
+        val result = service.submitBTN(validPlrId, validBTNRequest)
+
+        result shouldFailWith AccountingPeriodUnderEnquiry
       }
 
       "successfully submit a BTN when no existing submission for period" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/services/OrganisationServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/services/OrganisationServiceSpec.scala
@@ -49,7 +49,7 @@ class OrganisationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
         .thenReturn(Future.successful(true))
 
       val result = service.createOrganisation(validPlrId, organisationDetails).futureValue
-      result shouldBe organisationWithId
+      result shouldBe organisationWithId.withUnderEnquiry(organisationWithId)
       verify(mockRepository, times(1)).findByPillar2Id(validPlrId)
       verify(mockRepository, times(1)).insert(organisationWithId)
     }
@@ -89,7 +89,7 @@ class OrganisationServiceSpec extends AnyWordSpec with Matchers with MockitoSuga
         .thenReturn(Future.successful(Some(organisationWithId)))
 
       val result = service.getOrganisation(validPlrId).futureValue
-      result shouldBe organisationWithId
+      result shouldBe organisationWithId.withUnderEnquiry(organisationWithId)
       verify(mockRepository, times(1)).findByPillar2Id(validPlrId)
     }
 


### PR DESCRIPTION
To better match downstream and be used in validation later

To create a test organisation with an accounting period under enquiry:
```{
  "orgDetails": {
    "domesticOnly": false,
    "organisationName": "Test Organisation Ltd",
    "registrationDate": "2024-01-01"
  },
  "accountingPeriod": {
    "startDate": "2024-01-01",
    "endDate": "2024-12-31",
    "underEnquiry": true
  }
}