### PR TITLE
PIL-2356 - Update obligation MTT logic

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
@@ -162,20 +162,22 @@ object UKTRLiabilityReturn {
       )
   }
 
-  private[uktr] val nonMTTAmountsRule: ValidationRule[UKTRLiabilityReturn] = ValidationRule { data =>
-    if (
-      !data.obligationMTT && (
-        data.liabilities.totalLiabilityIIR > 0 ||
-          data.liabilities.totalLiabilityUTPR > 0 ||
-          data.liabilities.liableEntities.exists(entity => entity.amountOwedIIR > 0 || entity.amountOwedUTPR > 0)
-      )
-    ) {
-      invalid(
-        UKTRSubmissionError(
-          InvalidReturn
-        )
-      )
-    } else valid[UKTRLiabilityReturn](data)
+  private[uktr] def mttLiabilityValidationRule(org: TestOrganisationWithId): ValidationRule[UKTRLiabilityReturn] = ValidationRule { data =>
+    val isDomestic = org.organisation.orgDetails.domesticOnly
+    val hasMTTLiabilities =
+      data.liabilities.totalLiabilityIIR > 0 ||
+        data.liabilities.totalLiabilityUTPR > 0 ||
+        data.liabilities.liableEntities.exists(entity => entity.amountOwedIIR > 0 || entity.amountOwedUTPR > 0)
+
+    (isDomestic, data.obligationMTT, hasMTTLiabilities) match {
+      case (true, _, true) =>
+        invalid(UKTRSubmissionError(InvalidReturn))
+
+      case (false, false, true) =>
+        invalid(UKTRSubmissionError(InvalidReturn))
+
+      case _ => valid(data)
+    }
   }
 
   def uktrSubmissionValidator(
@@ -185,7 +187,7 @@ object UKTRLiabilityReturn {
       .getOrganisation(plrReference)
       .map { org =>
         ValidationRule.compose(
-          UKTRValidationRules.obligationMTTRule[UKTRLiabilityReturn](org),
+          mttLiabilityValidationRule(org),
           UKTRValidationRules.electionUKGAAPRule[UKTRLiabilityReturn](org),
           accountingPeriodMatchesOrgRule[UKTRLiabilityReturn](org, UKTRSubmissionError(InvalidReturn)),
           accountingPeriodSanityCheckRule[UKTRLiabilityReturn](UKTRSubmissionError(InvalidReturn)),
@@ -198,8 +200,7 @@ object UKTRLiabilityReturn {
           totalLiabilityUTPRRule(org),
           ukChargeableEntityNameRule,
           idTypeRule,
-          idValueRule,
-          nonMTTAmountsRule
+          idValueRule
         )(FailFast)
       }
       .recover { case _: OrganisationNotFound =>

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRNilReturn.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRNilReturn.scala
@@ -45,7 +45,6 @@ object UKTRNilReturn {
       .getOrganisation(plrReference)
       .map { org =>
         ValidationRule.compose(
-          UKTRValidationRules.obligationMTTRule[UKTRNilReturn](org),
           UKTRValidationRules.electionUKGAAPRule[UKTRNilReturn](org),
           accountingPeriodMatchesOrgRule[UKTRNilReturn](org, UKTRSubmissionError(InvalidReturn)),
           accountingPeriodSanityCheckRule[UKTRNilReturn](UKTRSubmissionError(InvalidReturn))

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/UKTRDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/UKTRDataFixture.scala
@@ -558,4 +558,139 @@ trait UKTRDataFixture extends Pillar2DataFixture with TestOrgDataFixture {
       )
     )
   )
+
+  def domesticGroupWithMTTLiabilities: JsObject = Json.obj(
+    "accountingPeriodFrom" -> accountingPeriod.startDate.toString,
+    "accountingPeriodTo"   -> accountingPeriod.endDate.toString,
+    "obligationMTT"        -> false,
+    "electionUKGAAP"       -> false,
+    "liabilities" -> Json.obj(
+      "electionDTTSingleMember"  -> true,
+      "electionUTPRSingleMember" -> false,
+      "numberSubGroupDTT"        -> 1,
+      "numberSubGroupUTPR"       -> 0,
+      "totalLiability"           -> 200,
+      "totalLiabilityDTT"        -> 100,
+      "totalLiabilityIIR"        -> 100,
+      "totalLiabilityUTPR"       -> 0,
+      "liableEntities" -> Json.arr(
+        Json.obj(
+          "ukChargeableEntityName" -> "New Company",
+          "idType"                 -> "CRN",
+          "idValue"                -> "1234",
+          "amountOwedDTT"          -> 100,
+          "amountOwedIIR"          -> 100,
+          "amountOwedUTPR"         -> 0
+        )
+      )
+    )
+  )
+
+  def domesticGroupWithoutMTTLiabilities: JsObject = Json.obj(
+    "accountingPeriodFrom" -> accountingPeriod.startDate.toString,
+    "accountingPeriodTo"   -> accountingPeriod.endDate.toString,
+    "obligationMTT"        -> false,
+    "electionUKGAAP"       -> false,
+    "liabilities" -> Json.obj(
+      "electionDTTSingleMember"  -> true,
+      "electionUTPRSingleMember" -> false,
+      "numberSubGroupDTT"        -> 1,
+      "numberSubGroupUTPR"       -> 0,
+      "totalLiability"           -> 100,
+      "totalLiabilityDTT"        -> 100,
+      "totalLiabilityIIR"        -> 0,
+      "totalLiabilityUTPR"       -> 0,
+      "liableEntities" -> Json.arr(
+        Json.obj(
+          "ukChargeableEntityName" -> "New Company",
+          "idType"                 -> "CRN",
+          "idValue"                -> "1234",
+          "amountOwedDTT"          -> 100,
+          "amountOwedIIR"          -> 0,
+          "amountOwedUTPR"         -> 0
+        )
+      )
+    )
+  )
+
+  def mneGroupWithNoMTTObligationButMTTLiabilities: JsObject = Json.obj(
+    "accountingPeriodFrom" -> accountingPeriod.startDate.toString,
+    "accountingPeriodTo"   -> accountingPeriod.endDate.toString,
+    "obligationMTT"        -> false,
+    "electionUKGAAP"       -> false,
+    "liabilities" -> Json.obj(
+      "electionDTTSingleMember"  -> true,
+      "electionUTPRSingleMember" -> false,
+      "numberSubGroupDTT"        -> 1,
+      "numberSubGroupUTPR"       -> 0,
+      "totalLiability"           -> 200,
+      "totalLiabilityDTT"        -> 100,
+      "totalLiabilityIIR"        -> 100,
+      "totalLiabilityUTPR"       -> 0,
+      "liableEntities" -> Json.arr(
+        Json.obj(
+          "ukChargeableEntityName" -> "New Company",
+          "idType"                 -> "CRN",
+          "idValue"                -> "1234",
+          "amountOwedDTT"          -> 100,
+          "amountOwedIIR"          -> 100,
+          "amountOwedUTPR"         -> 0
+        )
+      )
+    )
+  )
+
+  def mneGroupWithMTTObligation: JsObject = Json.obj(
+    "accountingPeriodFrom" -> accountingPeriod.startDate.toString,
+    "accountingPeriodTo"   -> accountingPeriod.endDate.toString,
+    "obligationMTT"        -> true,
+    "electionUKGAAP"       -> false,
+    "liabilities" -> Json.obj(
+      "electionDTTSingleMember"  -> true,
+      "electionUTPRSingleMember" -> false,
+      "numberSubGroupDTT"        -> 1,
+      "numberSubGroupUTPR"       -> 0,
+      "totalLiability"           -> 200,
+      "totalLiabilityDTT"        -> 100,
+      "totalLiabilityIIR"        -> 100,
+      "totalLiabilityUTPR"       -> 0,
+      "liableEntities" -> Json.arr(
+        Json.obj(
+          "ukChargeableEntityName" -> "New Company",
+          "idType"                 -> "CRN",
+          "idValue"                -> "1234",
+          "amountOwedDTT"          -> 100,
+          "amountOwedIIR"          -> 100,
+          "amountOwedUTPR"         -> 0
+        )
+      )
+    )
+  )
+
+  def mneGroupWithNoMTTObligationAndNoMTTLiabilities: JsObject = Json.obj(
+    "accountingPeriodFrom" -> accountingPeriod.startDate.toString,
+    "accountingPeriodTo"   -> accountingPeriod.endDate.toString,
+    "obligationMTT"        -> false,
+    "electionUKGAAP"       -> false,
+    "liabilities" -> Json.obj(
+      "electionDTTSingleMember"  -> true,
+      "electionUTPRSingleMember" -> false,
+      "numberSubGroupDTT"        -> 1,
+      "numberSubGroupUTPR"       -> 0,
+      "totalLiability"           -> 100,
+      "totalLiabilityDTT"        -> 100,
+      "totalLiabilityIIR"        -> 0,
+      "totalLiabilityUTPR"       -> 0,
+      "liableEntities" -> Json.arr(
+        Json.obj(
+          "ukChargeableEntityName" -> "New Company",
+          "idType"                 -> "CRN",
+          "idValue"                -> "1234",
+          "amountOwedDTT"          -> 100,
+          "amountOwedIIR"          -> 0,
+          "amountOwedUTPR"         -> 0
+        )
+      )
+    )
+  )
 }

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturnSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturnSpec.scala
@@ -25,7 +25,7 @@ import play.api.libs.json.Json
 import uk.gov.hmrc.pillar2externalteststub.helpers.TestOrgDataFixture
 import uk.gov.hmrc.pillar2externalteststub.helpers.UKTRDataFixture
 import uk.gov.hmrc.pillar2externalteststub.models.error.ETMPError._
-import uk.gov.hmrc.pillar2externalteststub.validation.ValidationResult.{ValidationResult, invalid, valid}
+import uk.gov.hmrc.pillar2externalteststub.validation.ValidationResult.{invalid, valid}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -138,26 +138,46 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
     }
 
     "should fail validation when liableEntities is empty" in {
-      val invalidReturn = validLiabilityReturn.copy(
-        liabilities = validLiabilityReturn.liabilities.copy(
-          electionDTTSingleMember = false,
-          electionUTPRSingleMember = false,
-          numberSubGroupDTT = 0,
-          numberSubGroupUTPR = 0,
-          liableEntities = Seq.empty
-        )
-      )
-      val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
+      val invalidReturn = Json.fromJson[UKTRLiabilityReturn](emptyLiableEntitiesJson).get
+      val result        = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
       result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
     }
 
-    "should fail validation when obligationMTT is true for domestic organisation" in {
-      when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(domesticOrganisation))
-      val invalidReturn = validLiabilityReturn.copy(
-        obligationMTT = true
-      )
-      val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
-      result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
+    "MTT Liability Validation" - {
+      "should fail when domestic group submits MTT liabilities" in {
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(domesticOrganisation))
+        val invalidReturn = Json.fromJson[UKTRLiabilityReturn](domesticGroupWithMTTLiabilities).get
+        val result        = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
+        result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
+      }
+
+      "should pass when domestic group submits without MTT liabilities" in {
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(domesticOrganisation))
+        val validReturn = Json.fromJson[UKTRLiabilityReturn](domesticGroupWithoutMTTLiabilities).get
+        val result      = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(validReturn)), 5.seconds)
+        result mustEqual valid(validReturn)
+      }
+
+      "should fail when MNE group with no MTT obligation submits MTT liabilities" in {
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
+        val invalidReturn = Json.fromJson[UKTRLiabilityReturn](mneGroupWithNoMTTObligationButMTTLiabilities).get
+        val result        = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
+        result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
+      }
+
+      "should pass when MNE group with MTT obligation submits" in {
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
+        val validReturn = Json.fromJson[UKTRLiabilityReturn](mneGroupWithMTTObligation).get
+        val result      = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(validReturn)), 5.seconds)
+        result mustEqual valid(validReturn)
+      }
+
+      "should pass when MNE group with no MTT obligation submits without MTT liabilities" in {
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
+        val validReturn = Json.fromJson[UKTRLiabilityReturn](mneGroupWithNoMTTObligationAndNoMTTLiabilities).get
+        val result      = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(validReturn)), 5.seconds)
+        result mustEqual valid(validReturn)
+      }
     }
 
     "should fail validation when electionUKGAAP is true for non-domestic organisation" in {
@@ -170,11 +190,8 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
     }
 
     "should fail validation when accounting period doesn't match organisation's" in {
-      val invalidReturn = validLiabilityReturn.copy(
-        accountingPeriodFrom = validLiabilityReturn.accountingPeriodFrom.plusDays(1),
-        accountingPeriodTo = validLiabilityReturn.accountingPeriodTo.plusDays(1)
-      )
-      val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
+      val invalidReturn = Json.fromJson[UKTRLiabilityReturn](invalidAccountingPeriodJson).get
+      val result        = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
       result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
     }
 
@@ -185,191 +202,32 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
       result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
     }
 
-    "should fail when a domestic-only organisation with obligationMTT = false has a positive total" - {
-      "total IIR liability is not nil" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(domesticOrganisation))
-
-        val invalidReturn = validLiabilityReturn.copy(
-          obligationMTT = false,
-          liabilities = validLiabilityReturn.liabilities.copy(
-            totalLiability = BigDecimal(300),
-            totalLiabilityIIR = BigDecimal(100)
-          )
-        )
-        val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
-        result mustEqual invalid(UKTRSubmissionError(InvalidTotalLiabilityIIR))
-      }
-
-      "total UTPR liability is not nil" in {
-        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(domesticOrganisation))
-
-        val invalidReturn = validLiabilityReturn.copy(
-          obligationMTT = false,
-          liabilities = validLiabilityReturn.liabilities.copy(
-            totalLiability = BigDecimal(200),
-            totalLiabilityIIR = BigDecimal(0),
-            totalLiabilityUTPR = BigDecimal(100),
-            liableEntities = validLiabilityReturn.liabilities.liableEntities.map(entity => entity.copy(amountOwedIIR = BigDecimal(0)))
-          )
-        )
-        val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
-        result mustEqual invalid(UKTRSubmissionError(InvalidTotalLiabilityUTPR))
-      }
-    }
-
-    "should fail validation when obligationMTT is false and IIR amount is greater than zero" in {
-      when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
-      val invalidReturn = validLiabilityReturn.copy(
-        obligationMTT = false,
-        liabilities = validLiabilityReturn.liabilities.copy(
-          electionDTTSingleMember = false,
-          electionUTPRSingleMember = false,
-          totalLiability = BigDecimal(200),
-          totalLiabilityIIR = BigDecimal(100),
-          totalLiabilityUTPR = BigDecimal(0),
-          totalLiabilityDTT = BigDecimal(100),
-          liableEntities = validLiabilityReturn.liabilities.liableEntities.map(entity =>
-            entity.copy(amountOwedIIR = BigDecimal(100), amountOwedUTPR = BigDecimal(0), amountOwedDTT = BigDecimal(100))
-          )
-        )
-      )
-
-      val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
-      result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
-    }
-
-    "should fail validation when obligationMTT is false and individual entity IIR amount is greater than zero even if total is zero" in {
-      when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
-      val invalidReturn = validLiabilityReturn.copy(
-        obligationMTT = false,
-        liabilities = validLiabilityReturn.liabilities.copy(
-          electionDTTSingleMember = false,
-          electionUTPRSingleMember = false,
-          totalLiability = BigDecimal(100),
-          totalLiabilityDTT = BigDecimal(0),
-          totalLiabilityIIR = BigDecimal(100),
-          totalLiabilityUTPR = BigDecimal(0),
-          liableEntities = validLiabilityReturn.liabilities.liableEntities.map(entity =>
-            entity.copy(amountOwedDTT = BigDecimal(0), amountOwedIIR = BigDecimal(100), amountOwedUTPR = BigDecimal(0))
-          )
-        )
-      )
-
-      val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
-      result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
-    }
-
-    "should fail validation when obligationMTT is false and UTPR amount is greater than zero" in {
-      when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
-
-      val invalidReturn = validLiabilityReturn.copy(
-        obligationMTT = false,
-        liabilities = validLiabilityReturn.liabilities.copy(
-          electionUTPRSingleMember = false,
-          numberSubGroupUTPR = 0,
-          totalLiability = BigDecimal(200),
-          totalLiabilityIIR = BigDecimal(0),
-          totalLiabilityUTPR = BigDecimal(100),
-          liableEntities = validLiabilityReturn.liabilities.liableEntities.map(entity =>
-            entity.copy(amountOwedIIR = BigDecimal(0), amountOwedUTPR = BigDecimal(100))
-          )
-        )
-      )
-
-      val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
-      result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
-    }
-
-    "should fail validation when obligationMTT is false and individual entity UTPR amount is greater than zero even if total is zero" in {
-      when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
-
-      val invalidReturn = validLiabilityReturn.copy(
-        obligationMTT = false,
-        liabilities = validLiabilityReturn.liabilities.copy(
-          electionDTTSingleMember = false,
-          numberSubGroupDTT = 0,
-          electionUTPRSingleMember = false,
-          numberSubGroupUTPR = 0,
-          totalLiability = BigDecimal(100),
-          totalLiabilityDTT = BigDecimal(0),
-          totalLiabilityIIR = BigDecimal(0),
-          totalLiabilityUTPR = BigDecimal(100),
-          liableEntities = validLiabilityReturn.liabilities.liableEntities.map(entity =>
-            entity.copy(amountOwedDTT = BigDecimal(0), amountOwedIIR = BigDecimal(0), amountOwedUTPR = BigDecimal(100))
-          )
-        )
-      )
-
-      val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
-      result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
-    }
-
-    "should pass validation when obligationMTT is false and both IIR and UTPR amounts are zero" in {
-      when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
-
-      val validReturn = validLiabilityReturn.copy(
-        obligationMTT = false,
-        liabilities = validLiabilityReturn.liabilities.copy(
-          electionUTPRSingleMember = false,
-          numberSubGroupUTPR = 0,
-          totalLiability = BigDecimal(100),
-          totalLiabilityIIR = BigDecimal(0),
-          totalLiabilityUTPR = BigDecimal(0),
-          liableEntities =
-            validLiabilityReturn.liabilities.liableEntities.map(entity => entity.copy(amountOwedIIR = BigDecimal(0), amountOwedUTPR = BigDecimal(0)))
-        )
-      )
-
-      val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(validReturn)), 5.seconds)
-      result mustEqual valid(validReturn)
-    }
-
-    "should pass validation when obligationMTT is true regardless of IIR and UTPR amounts" in {
-      when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
-
-      val validReturn = validLiabilityReturn.copy(
-        obligationMTT = true,
-        liabilities = validLiabilityReturn.liabilities.copy(
-          totalLiability = BigDecimal(300),
-          totalLiabilityIIR = BigDecimal(100),
-          totalLiabilityUTPR = BigDecimal(100),
-          liableEntities = validLiabilityReturn.liabilities.liableEntities.map(entity =>
-            entity.copy(amountOwedIIR = BigDecimal(100), amountOwedUTPR = BigDecimal(100))
-          )
-        )
-      )
-      val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(validReturn)), 5.seconds)
-      result mustEqual valid(validReturn)
-    }
-
     "should fail validation when election DTT data is invalid" - {
-      def result(implicit invalidReturn: UKTRLiabilityReturn): ValidationResult[UKTRLiabilityReturn] =
-        Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
 
       "electionDTTSingleMember = true yet numberSubGroupDTT = 0" in {
         when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
 
-        implicit val invalidReturn: UKTRLiabilityReturn =
-          validLiabilityReturn.copy(liabilities = validLiabilityReturn.liabilities.copy(numberSubGroupDTT = 0))
+        val invalidReturn = validLiabilityReturn.copy(liabilities = validLiabilityReturn.liabilities.copy(numberSubGroupDTT = 0))
 
+        val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
         result mustEqual invalid(UKTRSubmissionError(InvalidDTTElection))
       }
 
       "electionDTTSingleMember = true and the number of sub-groups does not match the liabile entities with positive amountOwedDTT" in {
         when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
 
-        implicit val invalidReturn: UKTRLiabilityReturn =
-          validLiabilityReturn.copy(liabilities = validLiabilityReturn.liabilities.copy(numberSubGroupDTT = 2))
+        val invalidReturn = validLiabilityReturn.copy(liabilities = validLiabilityReturn.liabilities.copy(numberSubGroupDTT = 2))
 
+        val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
         result mustEqual invalid(UKTRSubmissionError(InvalidDTTElection))
       }
 
       "invalid number of sub-groups" in {
         when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
 
-        implicit val invalidReturn: UKTRLiabilityReturn =
-          validLiabilityReturn.copy(liabilities = validLiabilityReturn.liabilities.copy(numberSubGroupDTT = -1))
+        val invalidReturn = validLiabilityReturn.copy(liabilities = validLiabilityReturn.liabilities.copy(numberSubGroupDTT = -1))
 
+        val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
         result mustEqual invalid(UKTRSubmissionError(InvalidDTTElection))
       }
     }

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRNilReturnSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRNilReturnSpec.scala
@@ -43,15 +43,6 @@ class UKTRNilReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFixture w
       result mustEqual valid(validNilReturn)
     }
 
-    "should fail validation when obligationMTT is true for domestic organisation" in {
-      when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(domesticOrganisation))
-      val invalidReturn = validNilReturn.copy(
-        obligationMTT = true
-      )
-      val result = Await.result(UKTRNilReturn.uktrNilReturnValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
-      result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
-    }
-
     "should fail validation when electionUKGAAP is true for non-domestic organisation" in {
       when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
       val invalidReturn = validNilReturn.copy(

--- a/test/uk/gov/hmrc/pillar2externalteststub/services/UKTRServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/services/UKTRServiceSpec.scala
@@ -211,98 +211,6 @@ class UKTRServiceSpec
           result shouldFailWith InvalidTotalLiability
         }
 
-        "should fail when submitting with obligationMTT false and IIR amount greater than zero" in {
-          when(mockOrgService.getOrganisation(eqTo(validPlrId)))
-            .thenReturn(Future.successful(nonDomesticOrganisation))
-
-          val liabilityReturn = liabilitySubmission.asInstanceOf[UKTRLiabilityReturn]
-          val invalidSubmission = liabilityReturn.copy(
-            obligationMTT = false,
-            liabilities = liabilityReturn.liabilities.copy(
-              electionUTPRSingleMember = false,
-              numberSubGroupUTPR = 0,
-              totalLiability = BigDecimal(200),
-              totalLiabilityIIR = BigDecimal(100),
-              totalLiabilityUTPR = BigDecimal(0),
-              liableEntities =
-                liabilityReturn.liabilities.liableEntities.map(entity => entity.copy(amountOwedIIR = BigDecimal(100), amountOwedUTPR = BigDecimal(0)))
-            )
-          )
-
-          val result = service.submitUKTR(validPlrId, invalidSubmission)
-          result shouldFailWith InvalidReturn
-        }
-
-        "should fail when submitting with obligationMTT false and UTPR amount greater than zero" in {
-          when(mockOrgService.getOrganisation(eqTo(validPlrId)))
-            .thenReturn(Future.successful(nonDomesticOrganisation))
-
-          val liabilityReturn = liabilitySubmission.asInstanceOf[UKTRLiabilityReturn]
-          val invalidSubmission = liabilityReturn.copy(
-            obligationMTT = false,
-            liabilities = liabilityReturn.liabilities.copy(
-              electionUTPRSingleMember = false,
-              numberSubGroupUTPR = 0,
-              totalLiability = BigDecimal(200),
-              totalLiabilityIIR = BigDecimal(0),
-              totalLiabilityUTPR = BigDecimal(100),
-              liableEntities =
-                liabilityReturn.liabilities.liableEntities.map(entity => entity.copy(amountOwedIIR = BigDecimal(0), amountOwedUTPR = BigDecimal(100)))
-            )
-          )
-
-          val result = service.submitUKTR(validPlrId, invalidSubmission)
-          result shouldFailWith InvalidReturn
-        }
-
-        "should fail when amending with obligationMTT false and IIR amount greater than zero" in {
-          when(mockOrgService.getOrganisation(eqTo(validPlrId)))
-            .thenReturn(Future.successful(nonDomesticOrganisation))
-          when(mockUKTRRepository.findByPillar2Id(eqTo(validPlrId)))
-            .thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
-
-          val liabilityReturn = liabilitySubmission.asInstanceOf[UKTRLiabilityReturn]
-          val invalidSubmission = liabilityReturn.copy(
-            obligationMTT = false,
-            liabilities = liabilityReturn.liabilities.copy(
-              electionUTPRSingleMember = false,
-              numberSubGroupUTPR = 0,
-              totalLiability = BigDecimal(200),
-              totalLiabilityIIR = BigDecimal(100),
-              totalLiabilityUTPR = BigDecimal(0),
-              liableEntities =
-                liabilityReturn.liabilities.liableEntities.map(entity => entity.copy(amountOwedIIR = BigDecimal(100), amountOwedUTPR = BigDecimal(0)))
-            )
-          )
-
-          val result = service.amendUKTR(validPlrId, invalidSubmission)
-          result shouldFailWith InvalidReturn
-        }
-
-        "should fail when amending with obligationMTT false and UTPR amount greater than zero" in {
-          when(mockOrgService.getOrganisation(eqTo(validPlrId)))
-            .thenReturn(Future.successful(nonDomesticOrganisation))
-          when(mockUKTRRepository.findByPillar2Id(eqTo(validPlrId)))
-            .thenReturn(Future.successful(Some(validGetByPillar2IdResponse)))
-
-          val liabilityReturn = liabilitySubmission.asInstanceOf[UKTRLiabilityReturn]
-          val invalidSubmission = liabilityReturn.copy(
-            obligationMTT = false,
-            liabilities = liabilityReturn.liabilities.copy(
-              electionUTPRSingleMember = false,
-              numberSubGroupUTPR = 0,
-              totalLiability = BigDecimal(200),
-              totalLiabilityIIR = BigDecimal(0),
-              totalLiabilityUTPR = BigDecimal(100),
-              liableEntities =
-                liabilityReturn.liabilities.liableEntities.map(entity => entity.copy(amountOwedIIR = BigDecimal(0), amountOwedUTPR = BigDecimal(100)))
-            )
-          )
-
-          val result = service.amendUKTR(validPlrId, invalidSubmission)
-          result shouldFailWith InvalidReturn
-        }
-
         "should succeed when submitting with obligationMTT false and both IIR and UTPR amounts are zero" in {
           when(mockOrgService.getOrganisation(eqTo(validPlrId)))
             .thenReturn(Future.successful(nonDomesticOrganisation))
@@ -426,18 +334,6 @@ class UKTRServiceSpec
       }
 
       "for nil returns" - {
-        "should fail when obligationMTT is true for domestic organisation" in {
-          when(mockOrgService.getOrganisation(eqTo(validPlrId)))
-            .thenReturn(Future.successful(domesticOrganisation))
-
-          val nilReturn = nilSubmission.asInstanceOf[UKTRNilReturn]
-          val invalidSubmission = nilReturn.copy(
-            obligationMTT = true
-          )
-
-          val result = service.submitUKTR(validPlrId, invalidSubmission)
-          result shouldFailWith InvalidReturn
-        }
 
         "should fail when electionUKGAAP is true for non-domestic organisation" in {
           when(mockOrgService.getOrganisation(eqTo(validPlrId)))


### PR DESCRIPTION
This change updates the validation for UKTR submissions to align with ETMP's business rules for Minimum Top-up Tax (MTT) liabilities. The new logic prevents the submission of inconsistent data based on the group's registration type and MTT obligation status.

The following validation rules have been implemented:
*   A submission from a 'Domestic only' group is rejected if it contains IIR or UTPR liabilities.
*   A submission from an 'MNE & UK' group with `obligationMTT` set to `false` is rejected if it contains IIR or UTPR liabilities.

**Technical Changes:**
*   Removed the obsolete `obligationMTTRule` from the validation rules.
*   Introduced a new `mttLiabilityValidationRule` in `UKTRLiabilityReturn` with the updated logic.
*   Updated unit tests to cover the new validation scenarios and removed obsolete tests.