### PR TITLE
[PIL-2361] - return InvalidReturn when MTT is false and IIR greater than 0

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
@@ -75,10 +75,10 @@ object UKTRLiabilityReturn {
 
     if (!notMTTLiableYetPositiveTotal && totalIIR == totalIIRAmountOwed)
       valid[UKTRLiabilityReturn](data)
-    else
-      invalid(
-        UKTRSubmissionError(InvalidTotalLiabilityIIR)
-      )
+    else {
+      val errorType = if (!data.obligationMTT && totalIIR > 0) InvalidReturn else InvalidTotalLiabilityIIR
+      invalid(UKTRSubmissionError(errorType))
+    }
   }
 
   private[uktr] def totalLiabilityUTPRRule(org: TestOrganisationWithId): ValidationRule[UKTRLiabilityReturn] = ValidationRule { data =>

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturnSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturnSpec.scala
@@ -197,7 +197,7 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
           )
         )
         val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
-        result mustEqual invalid(UKTRSubmissionError(InvalidTotalLiabilityIIR))
+        result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
       }
 
       "total UTPR liability is not nil" in {


### PR DESCRIPTION
We want to match ETMP's error responses.  This PR is about specifically changing the error to show InvalidReturn instead of InvalidTotalLiabilityIIR when MTT is false and IIR is greater than 0 