### PR TITLE
[PIL-2361] - return InvalidReturn when MTT is false and IIR is more than 0

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
@@ -77,7 +77,7 @@ object UKTRLiabilityReturn {
     if (!notMTTLiableYetPositiveTotal && totalIIR == totalIIRAmountOwed)
       valid[UKTRLiabilityReturn](data)
     else {
-      val errorType = if (!data.obligationMTT && totalIIR > 0) InvalidReturn else InvalidTotalLiabilityIIR
+      val errorType = if (!data.obligationMTT && notMTTLiableYetPositiveTotal) InvalidReturn else InvalidTotalLiabilityIIR
       invalid(UKTRSubmissionError(errorType))
     }
   }

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
@@ -77,7 +77,7 @@ object UKTRLiabilityReturn {
     if (!notMTTLiableYetPositiveTotal && totalIIR == totalIIRAmountOwed)
       valid[UKTRLiabilityReturn](data)
     else {
-      val errorType = if (!data.obligationMTT && notMTTLiableYetPositiveTotal) InvalidReturn else InvalidTotalLiabilityIIR
+      val errorType = if (!data.obligationMTT && totalIIR > 0) InvalidReturn else InvalidTotalLiabilityIIR
       invalid(UKTRSubmissionError(errorType))
     }
   }

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
@@ -76,10 +76,10 @@ object UKTRLiabilityReturn {
 
     if (!notMTTLiableYetPositiveTotal && totalIIR == totalIIRAmountOwed)
       valid[UKTRLiabilityReturn](data)
-    else
-      invalid(
-        UKTRSubmissionError(InvalidTotalLiabilityIIR)
-      )
+    else {
+      val errorType = if (!data.obligationMTT && totalIIR > 0) InvalidReturn else InvalidTotalLiabilityIIR
+      invalid(UKTRSubmissionError(errorType))
+    }
   }
 
   private[uktr] def totalLiabilityUTPRRule(org: TestOrganisationWithId): ValidationRule[UKTRLiabilityReturn] = ValidationRule { data =>

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturnSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturnSpec.scala
@@ -188,6 +188,18 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
         val result      = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(validReturn)), 5.seconds)
         result mustEqual valid(validReturn)
       }
+
+      "should fail validation when MTT is false and IIR is more than zero" in {
+        when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(domesticOrganisation))
+        val invalidReturn = validLiabilityReturn.copy(
+          obligationMTT = false,
+          liabilities = validLiabilityReturn.liabilities.copy(
+            totalLiabilityIIR = BigDecimal(100)
+          )
+        )
+        val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
+        result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
+      }
     }
 
     "should fail validation when electionUKGAAP is true for non-domestic organisation" in {

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturnSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturnSpec.scala
@@ -189,7 +189,7 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
         result mustEqual valid(validReturn)
       }
 
-      "should fail validation when MTT is false and IIR is more than zero" in {
+      "should fail validation when obligationMTT is false and IIR is more than zero" in {
         when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(domesticOrganisation))
         val invalidReturn = validLiabilityReturn.copy(
           obligationMTT = false,


### PR DESCRIPTION
We want to match ETMP's error responses. This PR is about specifically changing the error to show InvalidReturn instead of InvalidTotalLiabilityIIR when MTT is false and IIR is greater than 0