### PR TITLE
[PIL-2362] - return InvalidReturn when MTT is false and UTPR is more than zero

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
@@ -91,12 +91,10 @@ object UKTRLiabilityReturn {
 
     if (!notMTTLiableYetPositiveTotal && totalUTPR == totalUTPRAmountOwed)
       valid[UKTRLiabilityReturn](data)
-    else
-      invalid(
-        UKTRSubmissionError(
-          InvalidTotalLiabilityUTPR
-        )
-      )
+    else {
+      val errorType = if (!data.obligationMTT && totalUTPR > 0) InvalidReturn else InvalidTotalLiabilityUTPR
+      invalid(UKTRSubmissionError(errorType))
+    }
   }
 
   private[uktr] val liabilityEntityRule: ValidationRule[UKTRLiabilityReturn] = ValidationRule { data =>


### PR DESCRIPTION
We want to match ETMP's error responses. This PR is about specifically changing the error to show InvalidReturn instead of InvalidTotalLiabilityUTPR when MTT is false and UTPR is greater than 0