### PR TITLE
[PIL-2360] - remove UKGAAP validation

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
@@ -184,7 +184,6 @@ object UKTRLiabilityReturn {
       .map { org =>
         ValidationRule.compose(
           mttLiabilityValidationRule(org),
-          UKTRValidationRules.electionUKGAAPRule[UKTRLiabilityReturn](org),
           accountingPeriodMatchesOrgRule[UKTRLiabilityReturn](org, UKTRSubmissionError(InvalidReturn)),
           accountingPeriodSanityCheckRule[UKTRLiabilityReturn](UKTRSubmissionError(InvalidReturn)),
           electionDTTRule,

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRNilReturn.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRNilReturn.scala
@@ -45,7 +45,6 @@ object UKTRNilReturn {
       .getOrganisation(plrReference)
       .map { org =>
         ValidationRule.compose(
-          UKTRValidationRules.electionUKGAAPRule[UKTRNilReturn](org),
           accountingPeriodMatchesOrgRule[UKTRNilReturn](org, UKTRSubmissionError(InvalidReturn)),
           accountingPeriodSanityCheckRule[UKTRNilReturn](UKTRSubmissionError(InvalidReturn))
         )(FailFast)

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRValidationRules.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRValidationRules.scala
@@ -36,21 +36,4 @@ object UKTRValidationRules {
         )
       } else valid[T](data)
     }
-
-  // Common validation for electionUKGAAP - checks if non-domestic organisations can have electionUKGAAP set to true
-  def electionUKGAAPRule[T <: UKTRSubmission](
-    org: TestOrganisationWithId
-  ): ValidationRule[T] =
-    ValidationRule[T] { data =>
-      val isDomestic = org.organisation.orgDetails.domesticOnly
-      (data.electionUKGAAP, isDomestic) match {
-        case (true, false) =>
-          invalid(
-            UKTRSubmissionError(
-              InvalidReturn
-            )
-          )
-        case _ => valid[T](data)
-      }
-    }
 }

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturnSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturnSpec.scala
@@ -190,15 +190,6 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
       }
     }
 
-    "should fail validation when electionUKGAAP is true for non-domestic organisation" in {
-      when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
-      val invalidReturn = validLiabilityReturn.copy(
-        electionUKGAAP = true
-      )
-      val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
-      result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
-    }
-
     "should fail validation when accounting period doesn't match organisation's" in {
       val invalidReturn = Json.fromJson[UKTRLiabilityReturn](invalidAccountingPeriodJson).get
       val result        = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRNilReturnSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRNilReturnSpec.scala
@@ -43,15 +43,6 @@ class UKTRNilReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFixture w
       result mustEqual valid(validNilReturn)
     }
 
-    "should fail validation when electionUKGAAP is true for non-domestic organisation" in {
-      when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
-      val invalidReturn = validNilReturn.copy(
-        electionUKGAAP = true
-      )
-      val result = Await.result(UKTRNilReturn.uktrNilReturnValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
-      result mustEqual invalid(UKTRSubmissionError(InvalidReturn))
-    }
-
     "should fail validation when accounting period doesn't match organisation's" in {
       val invalidReturn = validNilReturn.copy(
         accountingPeriodFrom = validNilReturn.accountingPeriodFrom.plusDays(1),

--- a/test/uk/gov/hmrc/pillar2externalteststub/services/UKTRServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/services/UKTRServiceSpec.scala
@@ -332,22 +332,6 @@ class UKTRServiceSpec
           result shouldFailWith InvalidReturn
         }
       }
-
-      "for nil returns" - {
-
-        "should fail when electionUKGAAP is true for non-domestic organisation" in {
-          when(mockOrgService.getOrganisation(eqTo(validPlrId)))
-            .thenReturn(Future.successful(nonDomesticOrganisation))
-
-          val nilReturn = nilSubmission.asInstanceOf[UKTRNilReturn]
-          val invalidSubmission = nilReturn.copy(
-            electionUKGAAP = true
-          )
-
-          val result = service.submitUKTR(validPlrId, invalidSubmission)
-          result shouldFailWith InvalidReturn
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
ETMP does not have validation on whether UKGAAP must be true or false based on whether it is a domestic or non-domestic organisation. We will be matching their implementation by removing all UKGAAP validation in this PR