### PR TITLE
PIL-2359: idType and idValue - align validation with downstream

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
@@ -138,8 +138,9 @@ object UKTRLiabilityReturn {
       )
   }
 
+  // Validation rules for idType and idValue are now in the API, the two rules below are for added security
   private[uktr] val idTypeRule: ValidationRule[UKTRLiabilityReturn] = ValidationRule { data =>
-    if (data.liabilities.liableEntities.forall(f => f.idType.equals("UTR") || f.idType.equals("CRN"))) valid[UKTRLiabilityReturn](data)
+    if (data.liabilities.liableEntities.forall(f => f.idType.nonEmpty && f.idType.length <= 4)) valid[UKTRLiabilityReturn](data)
     else
       invalid(
         UKTRSubmissionError(


### PR DESCRIPTION
The validation for those two fields is now handled at the API layer, their validation rules here are kept for added security.