### PR TITLE
PIL-2414: Enforce DTT total validation for 098 error

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
@@ -57,7 +57,9 @@ object UKTRLiabilityReturn {
       acc + entity.amountOwedDTT
     }
 
-    if (data.liabilities.totalLiabilityDTT == totalDTTAmountOwed)
+    val declaredTotal = data.liabilities.totalLiabilityDTT
+
+    if (declaredTotal > 0 && declaredTotal == totalDTTAmountOwed)
       valid[UKTRLiabilityReturn](data)
     else
       invalid(


### PR DESCRIPTION
## Summary
Implements DTT total validation rule to return 422:098 when DTT total liability does not match sum of DTT amounts owed by liable entities.