### PR TITLE
[PIL-2469] - change electionUKGAAP to an optional field

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
@@ -33,7 +33,7 @@ case class UKTRLiabilityReturn(
   accountingPeriodFrom: LocalDate,
   accountingPeriodTo:   LocalDate,
   obligationMTT:        Boolean,
-  electionUKGAAP:       Boolean,
+  electionUKGAAP:       Option[Boolean],
   liabilities:          Liability
 ) extends UKTRSubmission
 

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRNilReturn.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRNilReturn.scala
@@ -31,7 +31,7 @@ case class UKTRNilReturn(
   accountingPeriodFrom: LocalDate,
   accountingPeriodTo:   LocalDate,
   obligationMTT:        Boolean,
-  electionUKGAAP:       Boolean,
+  electionUKGAAP:       Option[Boolean],
   liabilities:          LiabilityNilReturn
 ) extends UKTRSubmission
 

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRSubmission.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRSubmission.scala
@@ -27,7 +27,7 @@ trait UKTRSubmission extends BaseSubmission {
   val accountingPeriodFrom: LocalDate
   val accountingPeriodTo:   LocalDate
   val obligationMTT:        Boolean
-  val electionUKGAAP:       Boolean
+  val electionUKGAAP:       Option[Boolean]
   val liabilities:          Liabilities
 }
 


### PR DESCRIPTION
ETMP does not require the UKGAAP field to be present at all so this change is aligning our database to match their current functionality