### PR TITLE
Pil 2459

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
@@ -107,27 +107,33 @@ object UKTRLiabilityReturn {
   }
 
   private[uktr] val electionDTTRule: ValidationRule[UKTRLiabilityReturn] = ValidationRule { data =>
-    val isDTTSingleMember             = data.liabilities.electionDTTSingleMember
-    val subGroupDTTCount              = data.liabilities.numberSubGroupDTT
-    val positiveAmountOwedDTTEntities = data.liabilities.liableEntities.count(_.amountOwedDTT > 0)
+    val numberSubGroupDTT       = data.liabilities.numberSubGroupDTT
+    val numberOfLiableEntities  = data.liabilities.liableEntities.count(_.amountOwedDTT > 0)
+    val electionDTTSingleMember = data.liabilities.electionDTTSingleMember
 
-    if (
-      (isDTTSingleMember && subGroupDTTCount > 0 && subGroupDTTCount == positiveAmountOwedDTTEntities) ||
-      (!isDTTSingleMember && subGroupDTTCount >= 0)
-    ) valid[UKTRLiabilityReturn](data)
-    else invalid(UKTRSubmissionError(InvalidDTTElection))
+    val subgroupMissingWhenElected = electionDTTSingleMember && numberSubGroupDTT <= 0
+    val subgroupCountMismatch      = numberSubGroupDTT != numberOfLiableEntities
+
+    if (subgroupMissingWhenElected || subgroupCountMismatch) {
+      invalid(UKTRSubmissionError(InvalidDTTElection))
+    } else {
+      valid(data)
+    }
   }
 
   private[uktr] val electionUTPRRule: ValidationRule[UKTRLiabilityReturn] = ValidationRule { data =>
-    val isUTPRSingleMember             = data.liabilities.electionUTPRSingleMember
-    val subGroupUTPRCount              = data.liabilities.numberSubGroupUTPR
-    val positiveAmountOwedUTPREntities = data.liabilities.liableEntities.count(_.amountOwedUTPR > 0)
+    val numberSubGroupUTPR       = data.liabilities.numberSubGroupUTPR
+    val numberOfLiableEntities   = data.liabilities.liableEntities.count(_.amountOwedUTPR > 0)
+    val electionUTPRSingleMember = data.liabilities.electionUTPRSingleMember
 
-    if (
-      (isUTPRSingleMember && subGroupUTPRCount > 0 && subGroupUTPRCount == positiveAmountOwedUTPREntities) ||
-      (!isUTPRSingleMember && subGroupUTPRCount >= 0)
-    ) valid[UKTRLiabilityReturn](data)
-    else invalid(UKTRSubmissionError(InvalidUTPRElection))
+    val subgroupMissingWhenElected = electionUTPRSingleMember && numberSubGroupUTPR <= 0
+    val subgroupCountMismatch      = numberSubGroupUTPR != numberOfLiableEntities
+
+    if (subgroupMissingWhenElected || subgroupCountMismatch) {
+      invalid(UKTRSubmissionError(InvalidUTPRElection))
+    } else {
+      valid(data)
+    }
   }
 
   private[uktr] val ukChargeableEntityNameRule: ValidationRule[UKTRLiabilityReturn] = ValidationRule { data =>

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
@@ -107,12 +107,12 @@ object UKTRLiabilityReturn {
   }
 
   private[uktr] val electionDTTRule: ValidationRule[UKTRLiabilityReturn] = ValidationRule { data =>
-    val numberSubGroupDTT       = data.liabilities.numberSubGroupDTT
-    val numberOfLiableEntities  = data.liabilities.liableEntities.count(_.amountOwedDTT > 0)
-    val electionDTTSingleMember = data.liabilities.electionDTTSingleMember
+    val isDTTSingleMember = data.liabilities.electionDTTSingleMember
+    val subGroupDTTCount       = data.liabilities.numberSubGroupDTT
+    val positiveAmountOwedDTTEntities  = data.liabilities.liableEntities.count(_.amountOwedDTT > 0)
 
-    val subgroupMissingWhenElected = electionDTTSingleMember && numberSubGroupDTT <= 0
-    val subgroupCountMismatch      = numberSubGroupDTT != numberOfLiableEntities
+    val subgroupMissingWhenElected = isDTTSingleMember && subGroupDTTCount <= 0
+    val subgroupCountMismatch      = subGroupDTTCount != positiveAmountOwedDTTEntities
 
     if (subgroupMissingWhenElected || subgroupCountMismatch) {
       invalid(UKTRSubmissionError(InvalidDTTElection))
@@ -122,12 +122,12 @@ object UKTRLiabilityReturn {
   }
 
   private[uktr] val electionUTPRRule: ValidationRule[UKTRLiabilityReturn] = ValidationRule { data =>
-    val numberSubGroupUTPR       = data.liabilities.numberSubGroupUTPR
-    val numberOfLiableEntities   = data.liabilities.liableEntities.count(_.amountOwedUTPR > 0)
-    val electionUTPRSingleMember = data.liabilities.electionUTPRSingleMember
+    val isUTPRSingleMember = data.liabilities.electionUTPRSingleMember
+    val subGroupUTPRCount       = data.liabilities.numberSubGroupUTPR
+    val positiveAmountOwedUTPREntities   = data.liabilities.liableEntities.count(_.amountOwedUTPR > 0)
 
-    val subgroupMissingWhenElected = electionUTPRSingleMember && numberSubGroupUTPR <= 0
-    val subgroupCountMismatch      = numberSubGroupUTPR != numberOfLiableEntities
+    val subgroupMissingWhenElected = isUTPRSingleMember && subGroupUTPRCount <= 0
+    val subgroupCountMismatch      = subGroupUTPRCount != positiveAmountOwedUTPREntities
 
     if (subgroupMissingWhenElected || subgroupCountMismatch) {
       invalid(UKTRSubmissionError(InvalidUTPRElection))

--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
@@ -107,9 +107,9 @@ object UKTRLiabilityReturn {
   }
 
   private[uktr] val electionDTTRule: ValidationRule[UKTRLiabilityReturn] = ValidationRule { data =>
-    val isDTTSingleMember = data.liabilities.electionDTTSingleMember
-    val subGroupDTTCount       = data.liabilities.numberSubGroupDTT
-    val positiveAmountOwedDTTEntities  = data.liabilities.liableEntities.count(_.amountOwedDTT > 0)
+    val isDTTSingleMember             = data.liabilities.electionDTTSingleMember
+    val subGroupDTTCount              = data.liabilities.numberSubGroupDTT
+    val positiveAmountOwedDTTEntities = data.liabilities.liableEntities.count(_.amountOwedDTT > 0)
 
     val subgroupMissingWhenElected = isDTTSingleMember && subGroupDTTCount <= 0
     val subgroupCountMismatch      = subGroupDTTCount != positiveAmountOwedDTTEntities
@@ -122,9 +122,9 @@ object UKTRLiabilityReturn {
   }
 
   private[uktr] val electionUTPRRule: ValidationRule[UKTRLiabilityReturn] = ValidationRule { data =>
-    val isUTPRSingleMember = data.liabilities.electionUTPRSingleMember
-    val subGroupUTPRCount       = data.liabilities.numberSubGroupUTPR
-    val positiveAmountOwedUTPREntities   = data.liabilities.liableEntities.count(_.amountOwedUTPR > 0)
+    val isUTPRSingleMember             = data.liabilities.electionUTPRSingleMember
+    val subGroupUTPRCount              = data.liabilities.numberSubGroupUTPR
+    val positiveAmountOwedUTPREntities = data.liabilities.liableEntities.count(_.amountOwedUTPR > 0)
 
     val subgroupMissingWhenElected = isUTPRSingleMember && subGroupUTPRCount <= 0
     val subgroupCountMismatch      = subGroupUTPRCount != positiveAmountOwedUTPREntities


### PR DESCRIPTION
Fixed validation for DTT ands UTPR. Previously, we were allowing any amount of subgroup count as long as single member was false. This is not what is outlined in ETMP guidelines. We should still always match the subgroup count to the amount of liable entities even if single member is false