### PR TITLE
PIL-2779 - Update account activity examples

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/helpers/AccountActivityDataResponses.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/helpers/AccountActivityDataResponses.scala
@@ -527,9 +527,9 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
       transactionType = TransactionType.Payment,
       transactionDesc = PaymentOnAccountDesc,
       chargeRefNo = "XR23456789014".some,
-      originalAmount = 500,
+      originalAmount = -500,
       outstandingAmount = BigDecimal(0).some,
-      clearedAmount = BigDecimal(500).some,
+      clearedAmount = BigDecimal(-500).some,
       clearingDetails = Seq(
         clearingJson(
           transactionDesc = "Repayment",
@@ -573,8 +573,8 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
       accruedInterest.map("accruedInterest"                             -> JsNumber(_)),
       chargeRefNo.map("chargeRefNo"                                     -> JsString(_)),
       ("transactionDate" -> summon[Writes[LocalDate]].writes(today)).some,
-      ("dueDate"         -> summon[Writes[LocalDate]].writes(currentYearEnd.plusMonths(dueDateBuffer))).some,
-      ("originalAmount"  -> JsNumber(originalAmount)).some,
+      Option.when(transactionType == TransactionType.Debit)("dueDate" -> summon[Writes[LocalDate]].writes(currentYearEnd.plusMonths(dueDateBuffer))),
+      ("originalAmount" -> JsNumber(originalAmount)).some,
       outstandingAmount.map("outstandingAmount" -> JsNumber(_)),
       clearedAmount.map("clearedAmount"         -> JsNumber(_)),
       clearingDetails.map("clearingDetails"     -> JsArray(_)),
@@ -610,9 +610,9 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
   private type ClearingJson    = JsObject
 
   private enum TransactionType(val raw: String) {
-    case Debit extends TransactionType("Debit")
-    case Credit extends TransactionType("Credit")
-    case Payment extends TransactionType("Payment")
+    case Debit extends TransactionType("DEBIT")
+    case Credit extends TransactionType("CREDIT")
+    case Payment extends TransactionType("PAYMENT")
   }
 
 }
@@ -620,7 +620,7 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
 /** Transaction descriptions condensed to ≤30 chars for ETMP SAP limit */
 private enum TransactionDesc(val description: String) {
   // Payment
-  case PaymentOnAccountDesc extends TransactionDesc("On Account Pillar 2 (Payment on Account)")
+  case PaymentOnAccountDesc extends TransactionDesc("Pillar 2 Payment on Account")
 
   // UKTR charges
   case UktrDttDesc extends TransactionDesc("UKTR - DTT")

--- a/app/uk/gov/hmrc/pillar2externalteststub/helpers/AccountActivityDataResponses.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/helpers/AccountActivityDataResponses.scala
@@ -620,7 +620,7 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
 /** Transaction descriptions condensed to ≤30 chars for ETMP SAP limit */
 private enum TransactionDesc(val description: String) {
   // Payment
-  case PaymentOnAccountDesc extends TransactionDesc("Pillar 2 (Payment on Account)")
+  case PaymentOnAccountDesc extends TransactionDesc("On Account Pillar 2 (Payment on Account)")
 
   // UKTR charges
   case UktrDttDesc extends TransactionDesc("UKTR - DTT")

--- a/app/uk/gov/hmrc/pillar2externalteststub/helpers/AccountActivityDataResponses.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/helpers/AccountActivityDataResponses.scala
@@ -29,10 +29,12 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
   private def currentYearEnd   = LocalDate.of(today.getYear, 12, 31)
   private val dueDateBuffer    = 6
 
+  import TransactionDesc.*
+
   def DTTChargeResponse: JsObject = responseWrapper(
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 UK Tax Return Pillar 2 DTT",
+      transactionDesc = UktrDttDesc,
       chargeRefNo = "X123456789012".some,
       originalAmount = 10000,
       outstandingAmount = BigDecimal(10000).some,
@@ -45,14 +47,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
     responseWrapper(
       transactionJson(
         transactionType = TransactionType.Debit,
-        transactionDesc = "Pillar 2 UK Tax Return Pillar 2 DTT",
+        transactionDesc = UktrDttDesc,
         chargeRefNo = "X123456789012".some,
         originalAmount = 10000,
-        outstandingAmount = BigDecimal(10000).some,
+        outstandingAmount = None,
         clearedAmount = BigDecimal(10000).some,
         clearingDetails = Seq(
           clearingJson(
-            transactionDesc = "On Account Pillar 2 (Payment on Account)",
+            transactionDesc = PaymentOnAccountDesc,
             chargeRefNo = None,
             amount = 10000,
             clearingReason = "Cleared by Payment"
@@ -61,14 +63,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
       ),
       transactionJson(
         transactionType = TransactionType.Payment,
-        transactionDesc = "On Account Pillar 2 (Payment on Account)",
+        transactionDesc = PaymentOnAccountDesc,
         chargeRefNo = None,
-        originalAmount = 10000,
+        originalAmount = -10000,
         outstandingAmount = None,
-        clearedAmount = BigDecimal(10000).some,
+        clearedAmount = BigDecimal(-10000).some,
         clearingDetails = Seq(
           clearingJson(
-            transactionDesc = "Pillar 2 UK Tax Return Pillar 2 DTT",
+            transactionDesc = UktrDttDesc,
             chargeRefNo = "X123456789012".some,
             amount = 10000,
             clearingReason = "Allocated to Charge"
@@ -80,20 +82,20 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
   def FullyPaidChargeWithSplitPaymentsResponse: JsObject = responseWrapper(
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 UK Tax Return Pillar 2 DTT",
+      transactionDesc = UktrDttDesc,
       chargeRefNo = "X123456789012".some,
       originalAmount = 10000,
       outstandingAmount = None,
       clearedAmount = BigDecimal(10000).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "On Account Pillar 2 (Payment on Account)",
+          transactionDesc = PaymentOnAccountDesc,
           chargeRefNo = None,
           amount = 5000,
           clearingReason = "Cleared by Payment"
         ),
         clearingJson(
-          transactionDesc = "On Account Pillar 2 (Payment on Account)",
+          transactionDesc = PaymentOnAccountDesc,
           chargeRefNo = None,
           amount = 5000,
           clearingReason = "Cleared by Payment"
@@ -102,32 +104,32 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
     ),
     transactionJson(
       transactionType = TransactionType.Payment,
-      transactionDesc = "On Account Pillar 2 (Payment on Account)",
+      transactionDesc = PaymentOnAccountDesc,
       chargeRefNo = None,
-      originalAmount = 5000,
+      originalAmount = -5000,
       outstandingAmount = None,
-      clearedAmount = BigDecimal(5000).some,
+      clearedAmount = BigDecimal(-5000).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Pillar 2 UK Tax Return Pillar 2 DTT",
+          transactionDesc = UktrDttDesc,
           chargeRefNo = "X123456789012".some,
-          amount = 10000,
+          amount = 5000,
           clearingReason = "Allocated to Charge"
         )
       ).some
     ),
     transactionJson(
       transactionType = TransactionType.Payment,
-      transactionDesc = "On Account Pillar 2 (Payment on Account)",
+      transactionDesc = PaymentOnAccountDesc,
       chargeRefNo = None,
-      originalAmount = 5000,
+      originalAmount = -5000,
       outstandingAmount = None,
-      clearedAmount = BigDecimal(5000).some,
+      clearedAmount = BigDecimal(-5000).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Pillar 2 UK Tax Return Pillar 2 DTT",
+          transactionDesc = UktrDttDesc,
           chargeRefNo = "X123456789012".some,
-          amount = 10000,
+          amount = 5000,
           clearingReason = "Allocated to Charge"
         )
       ).some
@@ -137,14 +139,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
   def RepaymentInterestResponse: JsObject = responseWrapper(
     transactionJson(
       transactionType = TransactionType.Credit,
-      transactionDesc = "Pillar 2 UKTR RPI Pillar 2 OECD RPI",
+      transactionDesc = RepaymentInterestDesc,
       chargeRefNo = "XR23456789012".some,
       originalAmount = -100,
       outstandingAmount = None,
       clearedAmount = BigDecimal(-100).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Pillar 2 UK Tax Return Pillar 2 DTT",
+          transactionDesc = UktrDttDesc,
           chargeRefNo = "X123456789012".some,
           amount = 100,
           clearingReason = "Allocated to Charge"
@@ -156,7 +158,7 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
   def DTTDeterminationResponse: JsObject = responseWrapper(
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 Determination Pillar 2 DTT",
+      transactionDesc = DeterminationDttDesc,
       chargeRefNo = "XDT3456789698".some,
       originalAmount = 10000,
       outstandingAmount = BigDecimal(10000).some,
@@ -168,14 +170,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
   def DttIirUtprResponse: JsObject = responseWrapper(
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 UKTR Pillar 2 UKTR DTT",
+      transactionDesc = UktrDttDesc,
       chargeRefNo = "XDT3456789012".some,
       originalAmount = 3100,
       outstandingAmount = None,
       clearedAmount = BigDecimal(3100).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Pillar 2 UKTR Pillar 2 UKTR DTT",
+          transactionDesc = PaymentOnAccountDesc,
           chargeRefNo = None,
           amount = 3100,
           clearingReason = "Cleared by Payment"
@@ -184,14 +186,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
     ),
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 UKTR Pillar 2 UKTR IIR",
+      transactionDesc = UktrMttIirDesc,
       chargeRefNo = "XDT3456789012".some,
       originalAmount = 100,
       outstandingAmount = BigDecimal(50).some,
       clearedAmount = BigDecimal(50).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Pillar 2 UKTR Pillar 2 UKTR IIR",
+          transactionDesc = PaymentOnAccountDesc,
           chargeRefNo = None,
           amount = 50,
           clearingReason = "Cleared by Payment"
@@ -200,7 +202,7 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
     ),
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 UKTR Pillar 2 UKTR UTPR",
+      transactionDesc = UktrMttUtprDesc,
       chargeRefNo = "XDT3456789012".some,
       originalAmount = 100,
       outstandingAmount = BigDecimal(100).some,
@@ -212,7 +214,7 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
   def AccruedInterestResponse: JsObject = responseWrapper(
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 Determination Pillar 2 Determination IIR",
+      transactionDesc = DeterminationMttIirDesc,
       chargeRefNo = "XDT3456789055".some,
       originalAmount = 3100,
       outstandingAmount = BigDecimal(3100).some,
@@ -225,14 +227,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
   def DttIirUtprInterestResponse: JsObject = responseWrapper(
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 UKTR Interest UKTR DTT interest",
+      transactionDesc = LateUktrPayIntDttDesc,
       chargeRefNo = "XIN3456789642".some,
       originalAmount = 350,
       outstandingAmount = BigDecimal(150).some,
       clearedAmount = BigDecimal(200).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Pillar 2 UKTR Interest UKTR DTT interest",
+          transactionDesc = PaymentOnAccountDesc,
           chargeRefNo = None,
           amount = 200,
           clearingReason = "Cleared by Payment"
@@ -241,14 +243,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
     ),
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 UKTR Interest UKTR IIR interest",
+      transactionDesc = LateUktrPayIntMttIirDesc,
       chargeRefNo = "XIN3456789642".some,
       originalAmount = 150,
       outstandingAmount = None,
       clearedAmount = BigDecimal(150).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Pillar 2 UKTR Interest UKTR IIR interest",
+          transactionDesc = PaymentOnAccountDesc,
           chargeRefNo = None,
           amount = 150,
           clearingReason = "Cleared by Payment"
@@ -257,7 +259,7 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
     ),
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 UKTR Interest UKTR UTPR interest",
+      transactionDesc = LateUktrPayIntMttUtprDesc,
       chargeRefNo = "XIN3556789642".some,
       originalAmount = 35,
       outstandingAmount = BigDecimal(35).some,
@@ -269,14 +271,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
   def DttIirUtprDeterminationResponse: JsObject = responseWrapper(
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 Determination Pillar 2 Determination DTT",
+      transactionDesc = DeterminationDttDesc,
       chargeRefNo = "XDT3556789012".some,
       originalAmount = 310000,
       outstandingAmount = None,
       clearedAmount = BigDecimal(310000).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Pillar 2 Determination Pillar 2 Determination DTT",
+          transactionDesc = PaymentOnAccountDesc,
           chargeRefNo = None,
           amount = 310000,
           clearingReason = "Cleared by Payment"
@@ -285,14 +287,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
     ),
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 Determination Pillar 2 Determination IIR",
+      transactionDesc = DeterminationMttIirDesc,
       chargeRefNo = "XDT3556789012".some,
       originalAmount = 21250,
       outstandingAmount = BigDecimal(10000).some,
       clearedAmount = BigDecimal(11250).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Pillar 2 Determination Pillar 2 Determination IIR",
+          transactionDesc = PaymentOnAccountDesc,
           chargeRefNo = None,
           amount = 11250,
           clearingReason = "Cleared by Payment"
@@ -301,14 +303,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
     ),
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 Determination Pillar 2 Determination UTPR",
+      transactionDesc = DeterminationMttUtprDesc,
       chargeRefNo = "XDT3456789012".some,
       originalAmount = 1125,
       outstandingAmount = BigDecimal(1000).some,
       clearedAmount = BigDecimal(125).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Pillar 2 Determination Pillar 2 Determination UTPR",
+          transactionDesc = PaymentOnAccountDesc,
           chargeRefNo = None,
           amount = 125,
           clearingReason = "Cleared by Payment"
@@ -320,14 +322,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
   def DttIirUtprDiscoveryResponse: JsObject = responseWrapper(
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 Discovery Assessment Pillar 2 Discovery Assmt DTT",
+      transactionDesc = DiscoveryDttDesc,
       chargeRefNo = "XD23456789779".some,
       originalAmount = 350000,
       outstandingAmount = None,
       clearedAmount = BigDecimal(350000).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Pillar 2 Discovery Assessment Pillar 2 Discovery Assmt DTT",
+          transactionDesc = PaymentOnAccountDesc,
           chargeRefNo = None,
           amount = 350000,
           clearingReason = "Cleared by Payment"
@@ -336,14 +338,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
     ),
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 Discovery Assessment Pillar 2 Discovery Assmt IIR",
+      transactionDesc = DiscoveryMttIirDesc,
       chargeRefNo = "XD23456789779".some,
       originalAmount = 3000,
       outstandingAmount = BigDecimal(2000).some,
       clearedAmount = BigDecimal(1000).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Pillar 2 Discovery Assessment Pillar 2 Discovery Assmt IIR",
+          transactionDesc = PaymentOnAccountDesc,
           chargeRefNo = None,
           amount = 1000,
           clearingReason = "Cleared by Payment"
@@ -352,10 +354,10 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
     ),
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 Discovery Assessment Pillar 2 Discovery Assmt UTPR",
+      transactionDesc = DiscoveryMttUtprDesc,
       chargeRefNo = "XD23456789779".some,
       originalAmount = 3000,
-      outstandingAmount = BigDecimal(2000).some,
+      outstandingAmount = BigDecimal(3000).some,
       clearedAmount = None,
       clearingDetails = None
     )
@@ -364,7 +366,7 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
   def DttIirUtprOverpaidClaimResponse: JsObject = responseWrapper(
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 Overpaid Claim Assmt Pillar2 Overpaid Cl Assmt DTT",
+      transactionDesc = OverpaidClaimDttDesc,
       chargeRefNo = "XOC3456789456".some,
       originalAmount = 6100,
       outstandingAmount = BigDecimal(6100).some,
@@ -375,14 +377,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
     ),
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 Overpaid Claim Assmt Pillar2 Overpaid Cl Assmt IIR",
+      transactionDesc = OverpaidClaimMttIirDesc,
       chargeRefNo = "XOC3456789456".some,
       originalAmount = 5000,
       outstandingAmount = BigDecimal(2500).some,
       clearedAmount = BigDecimal(2500).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Pillar 2 Overpaid Claim Assmt Pillar2 Overpaid Cl Assmt IIR",
+          transactionDesc = PaymentOnAccountDesc,
           chargeRefNo = None,
           amount = 2500,
           clearingReason = "Cleared by Payment"
@@ -391,7 +393,7 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
     ),
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 Overpaid Claim Assmt Pillar2 Overpaid Cl Assmt UTPR",
+      transactionDesc = OverpaidClaimMttUtprDesc,
       chargeRefNo = "XOC3456789456".some,
       originalAmount = 4000,
       outstandingAmount = BigDecimal(4000).some,
@@ -403,14 +405,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
   def UktrDttMttLateFilingPenaltyResponse: JsObject = responseWrapper(
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 UKTR DTT LFP Pillar 2 UKTR DTT LFP",
+      transactionDesc = LateUktrSubPenDttDesc,
       chargeRefNo = None,
       originalAmount = 100,
       outstandingAmount = None,
       clearedAmount = BigDecimal(100).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Pillar 2 UKTR DTT LFP Pillar 2 UKTR DTT LFP",
+          transactionDesc = PaymentOnAccountDesc,
           chargeRefNo = None,
           amount = 100,
           clearingReason = "Cleared by Payment"
@@ -419,7 +421,7 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
     ),
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 UKTR MTT LFP Pillar 2 UKTR MTT LFP",
+      transactionDesc = LateUktrSubPenMttDesc,
       chargeRefNo = None,
       originalAmount = 100,
       outstandingAmount = BigDecimal(100).some,
@@ -431,14 +433,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
   def OrnGirDttUktrMttLateFilingPenaltyResponse: JsObject = responseWrapper(
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 ORN/GIR DTT LFP Pillar 2 ORN/GIR DTT LFP",
+      transactionDesc = LateOrnGirSubPenDttDesc,
       chargeRefNo = None,
       originalAmount = 100,
       outstandingAmount = None,
       clearedAmount = BigDecimal(100).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Pillar 2 ORN/GIR DTT LFP Pillar 2 ORN/GIR DTT LFP",
+          transactionDesc = PaymentOnAccountDesc,
           chargeRefNo = None,
           amount = 100,
           clearingReason = "Cleared by Payment"
@@ -447,14 +449,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
     ),
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 ORN/GIR MTT LFP Pillar 2 ORN/GIR MTT LFP",
+      transactionDesc = LateOrnGirSubPenMttDesc,
       chargeRefNo = None,
       originalAmount = 100,
       outstandingAmount = BigDecimal(50).some,
       clearedAmount = BigDecimal(50).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Pillar 2 ORN/GIR MTT LFP Pillar 2 ORN/GIR MTT LFP",
+          transactionDesc = PaymentOnAccountDesc,
           chargeRefNo = None,
           amount = 50,
           clearingReason = "Cleared by Payment"
@@ -466,14 +468,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
   def PotentialLostRevenuePenaltyResponse: JsObject = responseWrapper(
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 Potential Lost Rev Pen",
+      transactionDesc = Schedule24Desc,
       chargeRefNo = "XIN3456789011".some,
       originalAmount = 45000,
       outstandingAmount = BigDecimal(15000).some,
       clearedAmount = BigDecimal(30000).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Pillar 2 Potential Lost Rev Pen",
+          transactionDesc = PaymentOnAccountDesc,
           chargeRefNo = None,
           amount = 30000,
           clearingReason = "Cleared by Payment"
@@ -485,14 +487,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
   def Schedule36PenaltyResponse: JsObject = responseWrapper(
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Sch 36 penalty",
+      transactionDesc = Schedule36Desc,
       chargeRefNo = "XIN3456789444".some,
       originalAmount = 3500,
       outstandingAmount = BigDecimal(500).some,
       clearedAmount = BigDecimal(3000).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Sch 36 penalty",
+          transactionDesc = PaymentOnAccountDesc,
           chargeRefNo = None,
           amount = 3000,
           clearingReason = "Cleared by Payment"
@@ -504,14 +506,14 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
   def RecordKeepingPenaltyResponse: JsObject = responseWrapper(
     transactionJson(
       transactionType = TransactionType.Debit,
-      transactionDesc = "Pillar 2 Record Keeping Pen Pillar 2 Record Keeping Pen",
+      transactionDesc = RecordKeepingPenDesc,
       chargeRefNo = "XIN3456789898".some,
       originalAmount = 3500,
       outstandingAmount = None,
       clearedAmount = BigDecimal(3500).some,
       clearingDetails = Seq(
         clearingJson(
-          transactionDesc = "Pillar 2 Record Keeping Pen Pillar 2 Record Keeping Pen",
+          transactionDesc = PaymentOnAccountDesc,
           chargeRefNo = None,
           amount = 3500,
           clearingReason = "Cleared by Payment"
@@ -522,20 +524,27 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
 
   def RepaymentCreditResponse: JsObject = responseWrapper(
     transactionJson(
-      transactionType = TransactionType.Credit,
-      transactionDesc = "Pillar 2 UKTR Repayment Pillar 2 UKTR Repayment",
+      transactionType = TransactionType.Payment,
+      transactionDesc = PaymentOnAccountDesc,
       chargeRefNo = "XR23456789014".some,
-      originalAmount = -10000,
-      outstandingAmount = BigDecimal(-10000).some,
-      clearedAmount = None,
-      clearingDetails = None
+      originalAmount = 500,
+      outstandingAmount = BigDecimal(0).some,
+      clearedAmount = BigDecimal(500).some,
+      clearingDetails = Seq(
+        clearingJson(
+          transactionDesc = "Repayment",
+          chargeRefNo = None,
+          amount = 500,
+          clearingReason = "Outgoing payment - Paid"
+        )
+      ).some
     )
   )
 
   def InterestRepaymentCreditResponse: JsObject = responseWrapper(
     transactionJson(
       transactionType = TransactionType.Credit,
-      transactionDesc = "Pillar 2 UKTR RPI Pillar 2 UKTR RPI",
+      transactionDesc = "Repayment interest - UKTR",
       chargeRefNo = "XR23456789000".some,
       originalAmount = -100,
       outstandingAmount = BigDecimal(-100).some,
@@ -606,4 +615,81 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
     case Payment extends TransactionType("Payment")
   }
 
+}
+
+/** Transaction descriptions condensed to ≤30 chars for ETMP SAP limit */
+private enum TransactionDesc(val description: String) {
+  // Payment
+  case PaymentOnAccountDesc extends TransactionDesc("Pillar 2 (Payment on Account)")
+
+  // UKTR charges
+  case UktrDttDesc extends TransactionDesc("UKTR - DTT")
+  case UktrMttIirDesc extends TransactionDesc("UKTR - MTT (IIR)")
+  case UktrMttUtprDesc extends TransactionDesc("UKTR - MTT (UTPR)")
+
+  // Repayment interest
+  case RepaymentInterestDesc extends TransactionDesc("Repayment interest - UKTR")
+
+  // Determination charges
+  case DeterminationDttDesc extends TransactionDesc("Determination - DTT")
+  case DeterminationMttIirDesc extends TransactionDesc("Determination - MTT (IIR)")
+  case DeterminationMttUtprDesc extends TransactionDesc("Determination - MTT (UTPR)")
+
+  // Determination interest
+  case DeterminationIntDttDesc extends TransactionDesc("Determination interest - DTT")
+  case DeterminationIntMttIirDesc extends TransactionDesc("Determination int- MTT (IIR)")
+  case DeterminationIntMttUtprDesc extends TransactionDesc("Determination int - MTT (UTPR)")
+
+  // Discovery Assessment charges
+  case DiscoveryDttDesc extends TransactionDesc("Discovery Assessment - DTT")
+  case DiscoveryMttIirDesc extends TransactionDesc("Discovery Assessment-MTT(IIR)")
+  case DiscoveryMttUtprDesc extends TransactionDesc("Discovery Assessment-MTT(UTPR)")
+
+  // Discovery Assessment interest
+  case DiscoveryIntDttDesc extends TransactionDesc("Discovery Assessment int - DTT")
+  case DiscoveryIntMttIirDesc extends TransactionDesc("Discovery Assmnt int-MTT(IIR)")
+  case DiscoveryIntMttUtprDesc extends TransactionDesc("Discovery Assmnt int-MTT(UTPR)")
+
+  // Overpaid Claim Assessment charges
+  case OverpaidClaimDttDesc extends TransactionDesc("Overpaid claim assmnt - DTT")
+  case OverpaidClaimMttIirDesc extends TransactionDesc("O/paid claim assmnt-MTT (IIR)")
+  case OverpaidClaimMttUtprDesc extends TransactionDesc("O/paid claim assmnt-MTT (UTPR)")
+
+  // Overpaid Claim Assessment interest
+  case OverpaidClaimIntDttDesc extends TransactionDesc("O/paid claim assmnt int - DTT")
+  case OverpaidClaimIntMttIirDesc extends TransactionDesc("O/p claim assmnt int-MTT(IIR)")
+  case OverpaidClaimIntMttUtprDesc extends TransactionDesc("O/p claim assmnt int-MTT(UTPR)")
+
+  // Late UKTR payment interest
+  case LateUktrPayIntDttDesc extends TransactionDesc("Late UKTR pay int - DTT")
+  case LateUktrPayIntMttIirDesc extends TransactionDesc("Late UKTR pay int - MTT(IIR)")
+  case LateUktrPayIntMttUtprDesc extends TransactionDesc("Late UKTR pay int - MTT(UTPR)")
+
+  // Late submission penalties - UKTR
+  case LateUktrSubPenDttDesc extends TransactionDesc("Late UKTR sub pen - DTT")
+  case LateUktrSubPenDtt3MnthDesc extends TransactionDesc("Late UKTR sub pen - DTT 3mnth")
+  case LateUktrSubPenDtt6MnthDesc extends TransactionDesc("Late UKTR sub pen - DTT 6mnth")
+  case LateUktrSubPenDtt12MnthDesc extends TransactionDesc("Late UKTR sub pen - DTT 12mnth")
+  case LateUktrSubPenMttDesc extends TransactionDesc("Late UKTR sub pen - MTT")
+  case LateUktrSubPenMtt3MnthDesc extends TransactionDesc("Late UKTR sub pen - MTT 3mnth")
+  case LateUktrSubPenMtt6MnthDesc extends TransactionDesc("Late UKTR sub pen - MTT 6mnth")
+  case LateUktrSubPenMtt12MnthDesc extends TransactionDesc("Late UKTR sub pen - MTT 12mnth")
+
+  // Late submission penalties - ORN/GIR
+  case LateOrnGirSubPenDttDesc extends TransactionDesc("Late ORN/GIR sub pen - DTT")
+  case LateOrnGirSubPenDtt3MnthDesc extends TransactionDesc("Late ORN/GIR sub pen -DTT3mnth")
+  case LateOrnGirSubPenDtt6MnthDesc extends TransactionDesc("Late ORN/GIR sub pen -DTT6mnth")
+  case LateOrnGirSubPenMttDesc extends TransactionDesc("Late ORN/GIR sub pen - MTT")
+  case LateOrnGirSubPenMtt3MnthDesc extends TransactionDesc("Late ORN/GIR sub pen-MTT 3mnth")
+  case LateOrnGirSubPenMtt6MnthDesc extends TransactionDesc("Late ORN/GIR sub pen-MTT 6mnth")
+
+  // Other penalties
+  case Schedule36Desc extends TransactionDesc("Schedule 36 information notice")
+  case Schedule24Desc extends TransactionDesc("Schedule 24 inaccurate return")
+  case RecordKeepingPenDesc extends TransactionDesc("Accurate records failure pen")
+  case GaarPenaltyDesc extends TransactionDesc("General Anti Abuse Rule pen")
+}
+
+private object TransactionDesc {
+  given Conversion[TransactionDesc, String] = _.description
 }

--- a/app/uk/gov/hmrc/pillar2externalteststub/helpers/AccountActivityDataResponses.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/helpers/AccountActivityDataResponses.scala
@@ -208,6 +208,28 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
       outstandingAmount = BigDecimal(100).some,
       clearedAmount = None,
       clearingDetails = None
+    ),
+    transactionJson(
+      transactionType = TransactionType.Payment,
+      transactionDesc = PaymentOnAccountDesc,
+      chargeRefNo = None,
+      originalAmount = -3150,
+      outstandingAmount = None,
+      clearedAmount = BigDecimal(-3150).some,
+      clearingDetails = Seq(
+        clearingJson(
+          transactionDesc = UktrDttDesc,
+          chargeRefNo = "XDT3456789012".some,
+          amount = 3100,
+          clearingReason = "Allocated to Charge"
+        ),
+        clearingJson(
+          transactionDesc = UktrMttIirDesc,
+          chargeRefNo = "XDT3456789012".some,
+          amount = 50,
+          clearingReason = "Allocated to Charge"
+        )
+      ).some
     )
   )
 
@@ -265,6 +287,28 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
       outstandingAmount = BigDecimal(35).some,
       clearedAmount = None,
       clearingDetails = None
+    ),
+    transactionJson(
+      transactionType = TransactionType.Payment,
+      transactionDesc = PaymentOnAccountDesc,
+      chargeRefNo = None,
+      originalAmount = -350,
+      outstandingAmount = None,
+      clearedAmount = BigDecimal(-350).some,
+      clearingDetails = Seq(
+        clearingJson(
+          transactionDesc = LateUktrPayIntDttDesc,
+          chargeRefNo = "XIN3456789642".some,
+          amount = 200,
+          clearingReason = "Allocated to Charge"
+        ),
+        clearingJson(
+          transactionDesc = LateUktrPayIntMttIirDesc,
+          chargeRefNo = "XIN3456789642".some,
+          amount = 150,
+          clearingReason = "Allocated to Charge"
+        )
+      ).some
     )
   )
 
@@ -316,6 +360,34 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
           clearingReason = "Cleared by Payment"
         )
       ).some
+    ),
+    transactionJson(
+      transactionType = TransactionType.Payment,
+      transactionDesc = PaymentOnAccountDesc,
+      chargeRefNo = None,
+      originalAmount = -321375,
+      outstandingAmount = None,
+      clearedAmount = BigDecimal(-321375).some,
+      clearingDetails = Seq(
+        clearingJson(
+          transactionDesc = DeterminationDttDesc,
+          chargeRefNo = "XDT3556789012".some,
+          amount = 310000,
+          clearingReason = "Allocated to Charge"
+        ),
+        clearingJson(
+          transactionDesc = DeterminationMttIirDesc,
+          chargeRefNo = "XDT3556789012".some,
+          amount = 11250,
+          clearingReason = "Allocated to Charge"
+        ),
+        clearingJson(
+          transactionDesc = DeterminationMttUtprDesc,
+          chargeRefNo = "XDT3456789012".some,
+          amount = 125,
+          clearingReason = "Allocated to Charge"
+        )
+      ).some
     )
   )
 
@@ -360,6 +432,28 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
       outstandingAmount = BigDecimal(3000).some,
       clearedAmount = None,
       clearingDetails = None
+    ),
+    transactionJson(
+      transactionType = TransactionType.Payment,
+      transactionDesc = PaymentOnAccountDesc,
+      chargeRefNo = None,
+      originalAmount = -351000,
+      outstandingAmount = None,
+      clearedAmount = BigDecimal(-351000).some,
+      clearingDetails = Seq(
+        clearingJson(
+          transactionDesc = DiscoveryDttDesc,
+          chargeRefNo = "XD23456789779".some,
+          amount = 350000,
+          clearingReason = "Allocated to Charge"
+        ),
+        clearingJson(
+          transactionDesc = DiscoveryMttIirDesc,
+          chargeRefNo = "XD23456789779".some,
+          amount = 1000,
+          clearingReason = "Allocated to Charge"
+        )
+      ).some
     )
   )
 
@@ -399,6 +493,22 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
       outstandingAmount = BigDecimal(4000).some,
       clearedAmount = None,
       clearingDetails = None
+    ),
+    transactionJson(
+      transactionType = TransactionType.Payment,
+      transactionDesc = PaymentOnAccountDesc,
+      chargeRefNo = None,
+      originalAmount = -2500,
+      outstandingAmount = None,
+      clearedAmount = BigDecimal(-2500).some,
+      clearingDetails = Seq(
+        clearingJson(
+          transactionDesc = OverpaidClaimMttIirDesc,
+          chargeRefNo = "XOC3456789456".some,
+          amount = 2500,
+          clearingReason = "Allocated to Charge"
+        )
+      ).some
     )
   )
 
@@ -427,6 +537,22 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
       outstandingAmount = BigDecimal(100).some,
       clearedAmount = None,
       clearingDetails = None
+    ),
+    transactionJson(
+      transactionType = TransactionType.Payment,
+      transactionDesc = PaymentOnAccountDesc,
+      chargeRefNo = None,
+      originalAmount = -100,
+      outstandingAmount = None,
+      clearedAmount = BigDecimal(-100).some,
+      clearingDetails = Seq(
+        clearingJson(
+          transactionDesc = LateUktrSubPenDttDesc,
+          chargeRefNo = None,
+          amount = 100,
+          clearingReason = "Allocated to Charge"
+        )
+      ).some
     )
   )
 
@@ -462,6 +588,28 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
           clearingReason = "Cleared by Payment"
         )
       ).some
+    ),
+    transactionJson(
+      transactionType = TransactionType.Payment,
+      transactionDesc = PaymentOnAccountDesc,
+      chargeRefNo = None,
+      originalAmount = -150,
+      outstandingAmount = None,
+      clearedAmount = BigDecimal(-150).some,
+      clearingDetails = Seq(
+        clearingJson(
+          transactionDesc = LateOrnGirSubPenDttDesc,
+          chargeRefNo = None,
+          amount = 100,
+          clearingReason = "Allocated to Charge"
+        ),
+        clearingJson(
+          transactionDesc = LateOrnGirSubPenMttDesc,
+          chargeRefNo = None,
+          amount = 50,
+          clearingReason = "Allocated to Charge"
+        )
+      ).some
     )
   )
 
@@ -479,6 +627,22 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
           chargeRefNo = None,
           amount = 30000,
           clearingReason = "Cleared by Payment"
+        )
+      ).some
+    ),
+    transactionJson(
+      transactionType = TransactionType.Payment,
+      transactionDesc = PaymentOnAccountDesc,
+      chargeRefNo = None,
+      originalAmount = -30000,
+      outstandingAmount = None,
+      clearedAmount = BigDecimal(-30000).some,
+      clearingDetails = Seq(
+        clearingJson(
+          transactionDesc = Schedule24Desc,
+          chargeRefNo = "XIN3456789011".some,
+          amount = 30000,
+          clearingReason = "Allocated to Charge"
         )
       ).some
     )
@@ -500,6 +664,22 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
           clearingReason = "Cleared by Payment"
         )
       ).some
+    ),
+    transactionJson(
+      transactionType = TransactionType.Payment,
+      transactionDesc = PaymentOnAccountDesc,
+      chargeRefNo = None,
+      originalAmount = -3000,
+      outstandingAmount = None,
+      clearedAmount = BigDecimal(-3000).some,
+      clearingDetails = Seq(
+        clearingJson(
+          transactionDesc = Schedule36Desc,
+          chargeRefNo = "XIN3456789444".some,
+          amount = 3000,
+          clearingReason = "Allocated to Charge"
+        )
+      ).some
     )
   )
 
@@ -517,6 +697,22 @@ class AccountActivityDataResponses @Inject() (clock: Clock) {
           chargeRefNo = None,
           amount = 3500,
           clearingReason = "Cleared by Payment"
+        )
+      ).some
+    ),
+    transactionJson(
+      transactionType = TransactionType.Payment,
+      transactionDesc = PaymentOnAccountDesc,
+      chargeRefNo = None,
+      originalAmount = -3500,
+      outstandingAmount = None,
+      clearedAmount = BigDecimal(-3500).some,
+      clearingDetails = Seq(
+        clearingJson(
+          transactionDesc = RecordKeepingPenDesc,
+          chargeRefNo = "XIN3456789898".some,
+          amount = 3500,
+          clearingReason = "Allocated to Charge"
         )
       ).some
     )


### PR DESCRIPTION
### Summary
Updates the Account Activity stub to match the latest ETMP clarifications regarding transaction descriptions and signage.

### Changes
- Updated all transaction descriptions to be condensed (≤30 characters) to meet SAP/ETMP limits.
- Updated payment and credit amounts to be negative (signage fix).
- Corrected clearing details to refer to the clearing transaction rather than the original charge.
- Update the repayment example to be true to what it will look like