### PR TITLE
NOJIRA Fix totalLiabilityDTTRule logic for zero amounts

### DIFF
--- a/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturn.scala
@@ -51,14 +51,14 @@ object UKTRLiabilityReturn {
       )
   }
 
-  private[uktr] val totalLiabilityDTTRule: ValidationRule[UKTRLiabilityReturn] = ValidationRule { data =>
-    val totalDTTAmountOwed = data.liabilities.liableEntities.foldLeft(BigDecimal(0)) { (acc, entity) =>
-      acc + entity.amountOwedDTT
+  private[uktr] val totalLiabilityDTTRule: ValidationRule[UKTRLiabilityReturn] = ValidationRule { uKTRLiabilityReturn =>
+    val totalDTTAmountOwed: BigDecimal = uKTRLiabilityReturn.liabilities.liableEntities.foldLeft(BigDecimal(0)) { (acc, liableEntity) =>
+      acc + liableEntity.amountOwedDTT
     }
 
-    val declaredTotal = data.liabilities.totalLiabilityDTT
+    val totalDTTAmountDeclared: BigDecimal = uKTRLiabilityReturn.liabilities.totalLiabilityDTT
 
-    if declaredTotal > 0 && declaredTotal == totalDTTAmountOwed then valid[UKTRLiabilityReturn](data)
+    if totalDTTAmountDeclared >= 0 && totalDTTAmountDeclared == totalDTTAmountOwed then valid[UKTRLiabilityReturn](uKTRLiabilityReturn)
     else
       invalid(
         UKTRSubmissionError(

--- a/app/uk/gov/hmrc/pillar2externalteststub/validation/ValidationResult.scala
+++ b/app/uk/gov/hmrc/pillar2externalteststub/validation/ValidationResult.scala
@@ -15,6 +15,7 @@
  */
 
 package uk.gov.hmrc.pillar2externalteststub.validation
+
 import cats.data.{NonEmptyChain, ValidatedNec}
 import cats.implicits.*
 
@@ -27,6 +28,6 @@ object ValidationResult {
 
   def invalidNec[A](errors: NonEmptyChain[ValidationError]): ValidationResult[A] = errors.invalid
 
-  def sequence[A](results: Seq[ValidationResult[A]]): ValidationResult[Seq[A]] =
-    results.sequence
+  def sequence[A](results: Seq[ValidationResult[A]]): ValidationResult[Seq[A]] = results.sequence
+
 }

--- a/test/uk/gov/hmrc/pillar2externalteststub/helpers/UKTRDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/helpers/UKTRDataFixture.scala
@@ -65,7 +65,7 @@ trait UKTRDataFixture extends Pillar2DataFixture with TestOrgDataFixture {
     "liabilities"          -> Json.obj("returnType" -> "NIL_RETURN")
   )
 
-  val invalidLiableEntityukChargeableEntityNameZeroLength: JsObject = Json.obj(
+  val invalidLiableEntityUkChargeableEntityNameZeroLength: JsObject = Json.obj(
     "ukChargeableEntityName" -> "",
     "idType"                 -> "UTR",
     "idValue"                -> "abc45678",
@@ -215,7 +215,7 @@ trait UKTRDataFixture extends Pillar2DataFixture with TestOrgDataFixture {
       .deepMerge(
         Json.obj(
           "liableEntities" -> Json.arr(
-            invalidLiableEntityukChargeableEntityNameZeroLength
+            invalidLiableEntityUkChargeableEntityNameZeroLength
           )
         )
       )

--- a/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturnSpec.scala
+++ b/test/uk/gov/hmrc/pillar2externalteststub/models/uktr/UKTRLiabilityReturnSpec.scala
@@ -36,7 +36,8 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
 
   "UKTRLiabilityReturn validation" - {
     when(mockOrgService.getOrganisation(anyString())).thenReturn(Future.successful(nonDomesticOrganisation))
-    val validLiabilityReturn = Json.fromJson[UKTRLiabilityReturn](validRequestBody).get
+
+    val validLiabilityReturn: UKTRLiabilityReturn = Json.fromJson[UKTRLiabilityReturn](validRequestBody).get
 
     "should pass validation for a valid liability return" in {
       val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(validLiabilityReturn)), 5.seconds)
@@ -71,6 +72,20 @@ class UKTRLiabilityReturnSpec extends AnyFreeSpec with Matchers with UKTRDataFix
       )
       val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(invalidReturn)), 5.seconds)
       result mustEqual invalid(UKTRSubmissionError(InvalidTotalLiability))
+    }
+
+    "should pass validation when DTT total is zero and entity DTT amounts sum to zero" in {
+      val zeroDttReturn = validLiabilityReturn.copy(
+        liabilities = validLiabilityReturn.liabilities.copy(
+          electionDTTSingleMember = false,
+          numberSubGroupDTT = 0,
+          totalLiability = BigDecimal(200),
+          totalLiabilityDTT = BigDecimal(0),
+          liableEntities = validLiabilityReturn.liabilities.liableEntities.map(_.copy(amountOwedDTT = BigDecimal(0)))
+        )
+      )
+      val result = Await.result(UKTRLiabilityReturn.uktrSubmissionValidator("validPlrId").map(_.validate(zeroDttReturn)), 5.seconds)
+      result mustEqual valid(zeroDttReturn)
     }
 
     "should fail validation when DTT total does not match sum of DTT amounts" in {


### PR DESCRIPTION
Fixed logic in `totalLiabilityDTTRule`
When `totalDTTAmountOwed` and `totalDTTAmountDeclared` match, and are greater or equal to zero rule should pass validation.